### PR TITLE
Showing Tooltip triggers render for all visualization elements

### DIFF
--- a/app/src/components/Chart.tsx
+++ b/app/src/components/Chart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { memo, useEffect, useState } from "react"
 import {
   HydratedGitBlobObject,
   HydratedGitCommitObject,
@@ -100,7 +100,7 @@ export function Chart(props: ChartProps) {
   )
 }
 
-function Node({ d, isRoot }: { d: CircleOrRectHiearchyNode; isRoot: boolean }) {
+const Node = memo(function Node({ d, isRoot }: { d: CircleOrRectHiearchyNode; isRoot: boolean }) {
   const { chartType } = useOptions()
   let showLabel = !isRoot && isTree(d.data)
   const { searchText } = useSearch()
@@ -137,7 +137,7 @@ function Node({ d, isRoot }: { d: CircleOrRectHiearchyNode; isRoot: boolean }) {
     default:
       throw Error("Unknown chart type")
   }
-}
+})
 
 function Circle({
   d,


### PR DESCRIPTION
Fixes #353

Solution: Don't rerender nodes when not needed. 

This is done using [`memo` from React](https://reactjs.org/docs/react-api.html#reactmemo), which memoizes the component, such that it only renders when their props or hooks change.