### PR TITLE
Fix special characters

### DIFF
--- a/src/parser/parse.server.ts
+++ b/src/parser/parse.server.ts
@@ -14,6 +14,9 @@ import {
   getCurrentBranch,
   getRepoName,
   deflateGitObject,
+  getDefaultQuotePathValue,
+  disableQuotePath,
+  resetQuotePath,
 } from "./util"
 import { emptyGitCommitHash } from "./constants"
 import { resolve , isAbsolute, join} from "path"
@@ -224,6 +227,9 @@ export async function parse(rawArgs: string[]) {
 
   const branch = args.branch ?? null
 
+  const quotePathDefaultValue = await getDefaultQuotePathValue(repoDir)
+  await disableQuotePath(repoDir)
+
   const start = performance.now()
   const [branchHead, branchName] = await describeAsyncJob(
     () => findBranchHead(repoDir, branch),
@@ -267,6 +273,8 @@ export async function parse(rawArgs: string[]) {
   const stop = performance.now()
 
   log.raw(`\nDone in ${formatMs(stop - start)}`)
+
+  await resetQuotePath(repoDir, quotePathDefaultValue)
 
   return data
 }

--- a/src/parser/util.ts
+++ b/src/parser/util.ts
@@ -114,6 +114,28 @@ export async function deflateGitObject(repo: string, hash: string) {
   return result as string
 }
 
+export async function getDefaultQuotePathValue(repoDir: string) {
+  const result = await runProcess(repoDir, "git", ["config", "core.quotepath"])
+  return result as string
+}
+
+export async function disableQuotePath(repoDir: string) {
+  await runProcess(repoDir, "git", ["config", "core.quotepath", "off"])
+  log.debug("Disabled quotePath")
+}
+
+export async function resetQuotePath(repoDir: string, value: string) {
+  log.debug("value: " +  value)
+  if (!value) {
+    await runProcess(repoDir, "git", ["config", "--unset", "core.quotepath"])
+    log.debug("Unset quotePath")
+  } 
+  else {
+    await runProcess(repoDir, "git", ["config", "core.quotepath", value])
+    log.debug(`Reset quotePath to ${value}`)
+  } 
+}
+
 export async function writeRepoToFile(outPath: string, parsedData: ParserData) {
   const data = JSON.stringify(parsedData, null, 2)
   const dir = dirname(outPath)

--- a/src/parser/util.ts
+++ b/src/parser/util.ts
@@ -125,7 +125,6 @@ export async function disableQuotePath(repoDir: string) {
 }
 
 export async function resetQuotePath(repoDir: string, value: string) {
-  log.debug("value: " +  value)
   if (!value) {
     await runProcess(repoDir, "git", ["config", "--unset", "core.quotepath"])
     log.debug("Unset quotePath")


### PR DESCRIPTION
resolves #343 

now disables quotepath before parsing, and afterwards resets it back to what it was