### PR TITLE
Cache cat-file and diff

### DIFF
--- a/src/analyzer/analyze.server.ts
+++ b/src/analyzer/analyze.server.ts
@@ -15,11 +15,11 @@ import {
   writeRepoToFile,
   getCurrentBranch,
   getRepoName,
-  deflateGitObject,
   getDefaultGitSettingValue,
   resetGitSetting,
   setGitSetting,
 } from "./util"
+import { GitCaller } from "./git-caller"
 import { emptyGitCommitHash } from "./constants"
 import { resolve, isAbsolute, join } from "path"
 import { performance } from "perf_hooks"
@@ -27,7 +27,12 @@ import { getAuthorSet, hydrateData } from "./hydrate.server"
 import {} from "@remix-run/node"
 import { getArgs } from "./args.server"
 import ignore from "ignore"
-import { applyIgnore, applyMetrics, initMetrics, TreeCleanup } from "./postprocessing.server"
+import {
+  applyIgnore,
+  applyMetrics,
+  initMetrics,
+  TreeCleanup,
+} from "./postprocessing.server"
 import latestVersion from "latest-version"
 import pkg from "../../package.json"
 import { getCoAuthors } from "./coauthors.server"
@@ -49,15 +54,15 @@ export async function findBranchHead(repo: string, branch: string | null) {
 
   const branchHead = (await fs.readFile(branchPath, "utf-8")).trim()
   log.debug(`${branch} -> [commit]${branchHead}`)
+  if (!branchHead) throw Error("Branch head not found")
 
   return [branchHead, branch]
 }
 
 export async function analyzeCommitLight(
-  repo: string,
   hash: string
 ): Promise<GitCommitObjectLight> {
-  const rawContent = await deflateGitObject(repo, hash)
+  const rawContent = await GitCaller.getInstance().catFileCached(hash)
   const commitRegex =
     /tree (?<tree>.*)\n(?:parent (?<parent>.*)\n)?(?:parent (?<parent2>.*)\n)?author (?<authorName>.*) <(?<authorEmail>.*)> (?<authorTimeStamp>\d*) (?<authorTimeZone>.*)\ncommitter (?<committerName>.*) <(?<committerEmail>.*)> (?<committerTimeStamp>\d*) (?<committerTimeZone>.*)\n(?:gpgsig (?:.|\n)*-----END PGP SIGNATURE-----)?\s*(?<message>.*)\s*(?<description>(?:.|\s)*)/gm
 
@@ -98,24 +103,26 @@ export async function analyzeCommitLight(
 }
 
 export async function analyzeCommit(
-  repo: string,
   repoName: string,
   hash: string
 ): Promise<GitCommitObject> {
-  const { tree, ...commit } = await analyzeCommitLight(repo, hash)
-  return {
-    ...commit,
-    tree: await analyzeTree(getRepoName(repo), repo, repoName, tree),
+  if (hash === undefined) {
+    throw Error("Hash is required")
   }
+  const { tree, ...commit } = await analyzeCommitLight(hash)
+  const commitObject = {
+    ...commit,
+    tree: await analyzeTree(repoName, repoName, tree),
+  }
+  return commitObject
 }
 
 async function analyzeTree(
   path: string,
-  repo: string,
   name: string,
   hash: string
 ): Promise<GitTreeObject> {
-  const rawContent = await deflateGitObject(repo, hash)
+  const rawContent = await GitCaller.getInstance().catFileCached(hash)
   const entries = rawContent.split("\n").filter((x) => x.trim().length > 0)
 
   const children: (GitTreeObject | GitBlobObject)[] = []
@@ -132,11 +139,16 @@ async function analyzeTree(
 
     switch (type) {
       case "tree":
-        const tree = await analyzeTree(newPath, repo, name, hash)
-        children.push(tree)
+        children.push(await analyzeTree(newPath, name, hash))
         break
       case "blob":
-        children.push(await analyzeBlob(newPath, repo, name, hash))
+        children.push({
+          type: "blob",
+          hash,
+          path: newPath,
+          name,
+          content: await GitCaller.getInstance().catFileCached(hash),
+        })
         break
       default:
         throw new Error(` type ${type}`)
@@ -145,35 +157,21 @@ async function analyzeTree(
 
   return {
     type: "tree",
-    path: path,
+    path,
     name,
     hash,
     children,
   }
 }
 
-async function analyzeBlob(
-  path: string,
-  repo: string,
-  name: string,
-  hash: string
-): Promise<GitBlobObject> {
-  const content = await deflateGitObject(repo, hash)
-  const blob: GitBlobObject = {
-    type: "blob",
-    hash,
-    path,
-    name,
-    content,
-  }
-  return blob
-}
-
 function getCommandLine() {
-  switch (process.platform) { 
-     case 'darwin' : return 'open'; // MacOS
-     case 'win32' : return 'start'; // Windows
-     default : return 'xdg-open'; // Linux
+  switch (process.platform) {
+    case "darwin":
+      return "open" // MacOS
+    case "win32":
+      return "start" // Windows
+    default:
+      return "xdg-open" // Linux
   }
 }
 
@@ -202,6 +200,7 @@ export async function updateTruckConfig(
 
 export async function analyze(useCache = true) {
   const args = await getArgs()
+  GitCaller.initInstance(args.path)
 
   if (args?.log) {
     setLogLevel(args.log as string)
@@ -228,7 +227,9 @@ export async function analyze(useCache = true) {
   const dataPath = getOutPathFromRepoAndBranch(repoName, branchName)
   if (fsSync.existsSync(dataPath)) {
     const path = getOutPathFromRepoAndBranch(repoName, branchName)
-    const cachedData = JSON.parse(await fs.readFile(path, "utf8")) as AnalyzerData
+    const cachedData = JSON.parse(
+      await fs.readFile(path, "utf8")
+    ) as AnalyzerData
 
     // Check if the current branchHead matches the hash of the analyzed commit from the cache
     const branchHeadMatches = branchHead === cachedData.commit.hash
@@ -270,11 +271,12 @@ export async function analyze(useCache = true) {
 
     const runDateEpoch = Date.now()
     const repoTree = await describeAsyncJob(
-      () => analyzeCommit(repoDir, repoName, branchHead),
+      () => analyzeCommit(repoName, branchHead),
       "Analyzing commit tree",
       "Commit tree analyzed",
       "Error analyzing commit tree"
     )
+
     const hydratedRepoTree = await describeAsyncJob(
       () => hydrateData(repoDir, repoTree),
       "Hydrating commit tree",
@@ -291,7 +293,7 @@ export async function analyze(useCache = true) {
     if (!isAbsolute(outPath)) outPath = resolve(process.cwd(), outPath)
 
     let latestV: string | undefined
-  
+
     try {
       latestV = await latestVersion(pkg.name)
     } catch {}

--- a/src/analyzer/git-caller.ts
+++ b/src/analyzer/git-caller.ts
@@ -1,0 +1,84 @@
+import { runProcess } from "./util"
+
+export type RawGitObjectType = "blob" | "tree" | "commit" | "tag"
+export type RawGitObject = {
+  hash: string
+  type: RawGitObjectType
+  idk: string
+  value: string
+}
+
+export class GitCaller {
+  private useCache = true
+  private repo: string
+  private catFileCache: Map<string, string> = new Map()
+  private diffNumStatCache: Map<string, string> = new Map()
+
+  private static instance: GitCaller | null = null
+
+  static initInstance(repo: string) {
+    if (!GitCaller.instance || GitCaller.instance.repo !== repo) {
+      GitCaller.instance = new GitCaller(repo)
+    }
+  }
+
+  static destroyInstance() {
+    GitCaller.instance = null
+  }
+
+  static getInstance(): GitCaller {
+    if (!GitCaller.instance) {
+      throw Error("ObjectDeflator not initialized")
+    }
+    return GitCaller.instance
+  }
+
+  private constructor(repo: string) {
+    this.repo = repo
+  }
+
+  setUseCache(useCache: boolean) {
+    this.useCache = useCache
+  }
+
+  async catFileCached(hash: string): Promise<string> {
+    if (!this.useCache) {
+      const cachedValue = this.catFileCache.get(hash)
+      if (cachedValue) {
+        return cachedValue
+      }
+    }
+    const result = await this.catFile(hash)
+    this.catFileCache.set(hash, result)
+
+    return result
+  }
+
+  async gitDiffNumStatCached(a: string, b: string) {
+    const key = a + b
+    if (this.useCache) {
+      const cachedValue = this.diffNumStatCache.get(key)
+      if (cachedValue) {
+        return cachedValue
+      }
+    }
+    const result = await this.gitDiffNumStat(a, b)
+    this.diffNumStatCache.set(key, result)
+    return result
+  }
+
+  private async catFile(hash: string) {
+    const result = await runProcess(this.repo, "git", ["cat-file", "-p", hash])
+    return result as string
+  }
+
+  private async gitDiffNumStat(a: string, b: string) {
+    const result = await runProcess(this.repo, "git", [
+      "diff",
+      "--numstat",
+      a,
+      b,
+    ])
+    return result as string
+  }
+}

--- a/src/analyzer/hydrate.server.ts
+++ b/src/analyzer/hydrate.server.ts
@@ -133,7 +133,7 @@ async function diffAndUpdate_mut(
 
     if (file === "dev/null") continue
     if (blob) {
-      updateBlob_mut(blob, data, author, currCommit, pos, neg)
+      updateBlob_mut(blob, author, currCommit, pos, neg)
     }
   }
 }
@@ -144,7 +144,6 @@ function isBinaryFile(blob: GitBlobObject) {
 
 function updateBlob_mut(
   blob: GitBlobObject,
-  data: HydratedGitCommitObject,
   author: PersonWithTime,
   currCommit: GitCommitObjectLight,
   pos: number,

--- a/src/analyzer/hydrate.server.ts
+++ b/src/analyzer/hydrate.server.ts
@@ -38,7 +38,7 @@ export async function hydrateData(
 }
 
 export function getAuthorSet() {
-  return Array.from(authors);
+  return Array.from(authors)
 }
 
 function initially_mut(data: HydratedGitCommitObject) {
@@ -76,9 +76,9 @@ async function bfs(first: string, repo: string, data: HydratedGitCommitObject) {
     // don't compare the empty commit to it's parent
     if (currHash == emptyGitCommitHash) continue
 
-    const currCommit = await analyzeCommitLight(repo, currHash)
+    const currCommit = await analyzeCommitLight(currHash)
     authors.add((currCommit.author as Person).name)
-    for(const person of currCommit.coauthors) authors.add(person.name)
+    for (const person of currCommit.coauthors) authors.add(person.name)
 
     const parentsOfCurr = parents(currCommit)
 
@@ -122,7 +122,6 @@ async function diffAndUpdate_mut(
   log.debug(`comparing [${currHash}] -> [${parentHash}]`)
 
   const fileChanges = await gitDiffNumStatAnalyzed(
-    repo,
     parentHash,
     currHash,
     renamedFiles

--- a/src/analyzer/hydrate.server.ts
+++ b/src/analyzer/hydrate.server.ts
@@ -88,12 +88,12 @@ async function bfs(first: string, repo: string, data: HydratedGitCommitObject) {
           queue.enqueue(parentHash)
           break
         case 1: // curr is a linear commit
-          await diffAndUpdate_mut(data, currCommit, parentHash, repo)
+          await diffAndUpdate_mut(data, currCommit, parentHash)
           queue.enqueue(parentHash)
           break
         default:
           // curr is the root commit
-          await diffAndUpdate_mut(data, currCommit, emptyGitCommitHash, repo)
+          await diffAndUpdate_mut(data, currCommit, emptyGitCommitHash)
           break
       }
     }
@@ -113,7 +113,6 @@ async function diffAndUpdate_mut(
   data: HydratedGitCommitObject,
   currCommit: GitCommitObjectLight,
   parentHash: string,
-  repo: string
 ) {
   const { author } = currCommit
 

--- a/src/analyzer/util.ts
+++ b/src/analyzer/util.ts
@@ -219,8 +219,3 @@ export async function describeAsyncJob<T>(
     process.exit(1)
   }
 }
-
-export const removeFirstLine = (str: string) =>
-  str.split("\n").slice(1).join("\n")
-export const removeLastLine = (str: string) =>
-  str.split("\n").slice(0, -1).join("\n")


### PR DESCRIPTION
Presseng the "Rerun analyzer" button should take half the time as before, because `cat-file` and `diff` calls are now cached between runs. 