### PR TITLE
Fix path not breaking in safari

### DIFF
--- a/src/components/util.tsx
+++ b/src/components/util.tsx
@@ -207,6 +207,8 @@ export const DetailsKey = styled.span<{ grow?: boolean }>`
 
 export const DetailsValue = styled.p`
   overflow-wrap: anywhere;
+  word-wrap: break-word;
+  overflow: hidden;
   font-size: 0.9em;
 `
 


### PR DESCRIPTION
Fixed in Safari 12
![image](https://user-images.githubusercontent.com/1959615/166562850-482391e5-cea4-4293-a71c-21f5a47fed54.png)
