### PR TITLE
Update run-with-docker.sh

### DIFF
--- a/run-with-docker.sh
+++ b/run-with-docker.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
-# Note: tested on Mac OS, Linux and Windows MINGW64
-docker build -t gt .
-docker run --rm -it -u `id -u` -v `pwd`:`pwd` -w `pwd` -p 3000:3000 gt /usr/app/node_modules/.bin/git-truck --headless
+
+docker run --rm -it -u `id -u` -v `pwd`:`pwd` -w `pwd` -p 3000:3000  gittruck/git-truck /usr/app/node_modules/.bin/git-truck --headless
+
+# Alternatively, if you want to build locally befor running, uncomment the two lines below
+# docker build -t gt .
+# docker run --rm -it -u `id -u` -v `pwd`:`pwd` -w `pwd` -p 3000:3000 gt /usr/app/node_modules/.bin/git-truck --headless
+
+# Note: Above tested on Mac OS, Linux and Windows MINGW64
 
 


### PR DESCRIPTION
Now that we're automatically building and pushing to DockerHub on every new release, we should be able to run with docker w/o having to build locally, but instead simply pull from the DH. 

