### PR TITLE
[UI] Collapsible Panels

### DIFF
--- a/src/routes/$repo.$.tsx
+++ b/src/routes/$repo.$.tsx
@@ -246,21 +246,25 @@ export default function Repo() {
   return (
     <Providers data={data}>
       <div className={`app-container ${defineTheContainerClass()}`}>
-        <aside>
+        <aside className={clsx("flex flex-col gap-2 p-2 pl-0", {
+            "overflow-y-auto": !isFullscreen,
+          })}>
           {!isFullscreen ? (
-          <div className="relative z-10">
-            <div onClick={() => setIsLeftPanelCollapse(!isLeftPanelCollapse)} className="absolute left-97 top-half-screen rounded-full bg-white w-8 h-8 flex items-center cursor-pointer justify-center border-solid border-2 border-sky-500">
+          <div className="absolute z-10">
+            <div onClick={() => setIsLeftPanelCollapse(!isLeftPanelCollapse)} className={clsx("absolute top-half-screen rounded-full bg-white w-8 h-8 flex items-center cursor-pointer justify-center border-solid border-2 border-sky-500", {
+              "left-arrow-space": !isLeftPanelCollapse
+            })}>
               <Icon path={isLeftPanelCollapse ? mdiChevronRight : mdiChevronLeft} size={1} />
             </div>
           </div>
           ) : null}
           {!isLeftPanelCollapse ? (
-          <div className="flex flex-col gap-2 overflow-y-auto p-2 pr-0">
+          <>
             <GlobalInfo />
             <Options />
             {analyzerData.hiddenFiles.length > 0 ? <HiddenFiles /> : null}
             <SearchCard />
-          </div>
+          </>
           ) : null}
         </aside>
 
@@ -272,18 +276,18 @@ export default function Repo() {
           {client ? <ChartWrapper hoveredObject={hoveredObject} setHoveredObject={setHoveredObject} /> : <div />}
         </main>
 
-        <aside>
+        <aside className={clsx("flex flex-col gap-2 p-2 pl-0", {
+            "overflow-y-auto": !isFullscreen,
+          })}>
           {!isFullscreen ? (
-          <div className="relative z-10">
-            <div onClick={() => setIsRightPanelCollapse(!isRightPanelCollapse)} className="absolute right-97 top-half-screen rounded-full bg-white w-8 h-8 flex items-center cursor-pointer justify-center border-solid border-2 border-sky-500">
+          <div className="absolute z-10">
+            <div onClick={() => setIsRightPanelCollapse(!isRightPanelCollapse)} className="absolute right-0 top-half-screen rounded-full bg-white w-8 h-8 flex items-center cursor-pointer justify-center border-solid border-2 border-sky-500">
               <Icon path={isRightPanelCollapse ? mdiChevronLeft : mdiChevronRight} size={1} />
             </div>
           </div>
           ) : null}
           {!isRightPanelCollapse ? (
-          <div className={clsx("flex flex-col gap-2 p-2 pl-0", {
-            "overflow-y-auto": !isFullscreen,
-          })}>
+          <>
             {gitTruckInfo.latestVersion && semverCompare(gitTruckInfo.latestVersion, gitTruckInfo.version) === 1 ? (
               <UpdateNotifier />
             ) : null}
@@ -296,7 +300,7 @@ export default function Repo() {
             />
             <Legend hoveredObject={hoveredObject} showUnionAuthorsModal={showUnionAuthorsModal} />
             <FeedbackCard />
-          </div>
+          </>
           ) : null}
         </aside>
       </div>

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -133,6 +133,18 @@
     grid-area: right;
   }
 
+  .app-container.both-collapse {
+    @apply md:h-screen md:grid-cols-[0,1fr,0] md:grid-rows-[1fr] md:overflow-hidden;
+  }
+
+  .app-container.left-collapse {
+    @apply md:h-screen md:grid-cols-[0,1fr,var(--side-panel-width)] md:grid-rows-[1fr] md:overflow-hidden;
+  }
+
+  .app-container.right-collapse {
+    @apply md:h-screen md:grid-cols-[var(--side-panel-width),1fr,0] md:grid-rows-[1fr] md:overflow-hidden;
+  }
+
   .app-container.fullscreen {
     @apply grid-rows-[100vh,auto,auto];
   }

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -153,6 +153,10 @@
     /* Span all available columns */
     grid-column: 1 / -1;
   }
+  
+  .left-arrow-space {
+    left: var(--side-panel-width);
+  }
 
   .app-container.fullscreen > aside:first-of-type {
     @apply md:-translate-x-[var(--side-panel-width)];

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,10 @@ module.exports = {
         blink: "1s linear infinite blink",
         "stroke-pulse": "1s ease-in-out infinite stroke_pulse",
       },
+      inset: {
+        "half-screen": "50vh",
+        "97": "97%",
+      },
       fontFamily: {
         mono: ["Roboto Mono", "monospace"],
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,7 +10,6 @@ module.exports = {
       },
       inset: {
         "half-screen": "50vh",
-        "97": "97%",
       },
       fontFamily: {
         mono: ["Roboto Mono", "monospace"],


### PR DESCRIPTION
# Problem 

Currently, the view is fixed with the limited capability to focus on some areas of the product, for example, presenting changes to the detail view where we want to make details (right panel) wider than others. 

# Solution
We can tweak CSS to enable collapsible panels. This feature will help with the presentation of new features as well as creates the focus mode for a particular part of the visualisation. It does not change anything for users not interested in changing the current layout. The panels can be hidden by clicking the arrows next to the panels. 
![image](https://github.com/git-truck/git-truck/assets/52498300/31a36d87-bef9-42b6-9c86-0203745dbaa4)

The setting is reset to default after you refresh the page below are some examples of the layouts you can create using this CSS tweak. 
![image](https://github.com/git-truck/git-truck/assets/52498300/c3a1bc72-1506-49cd-8cbb-5f2ec925e539)
![image](https://github.com/git-truck/git-truck/assets/52498300/f4204363-41b3-4327-be2c-dd3481edfb23)
![image](https://github.com/git-truck/git-truck/assets/52498300/3a742ec9-d4dc-4c7a-a62f-b76bc8088576)
![image](https://github.com/git-truck/git-truck/assets/52498300/26d62b52-0647-40e1-b387-adf980e34cd3)
