### PR TITLE
Add hiearchy option

### DIFF
--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -1,8 +1,8 @@
 import type { MetricType } from "../metrics/metrics"
 import { Metric } from "../metrics/metrics"
 import { EnumSelect } from "./EnumSelect"
-import type { ChartType } from "../contexts/OptionsContext"
-import { Chart, useOptions } from "../contexts/OptionsContext"
+import type { ChartType, HierarchyType } from "../contexts/OptionsContext"
+import { Chart, Hierarchy, useOptions } from "../contexts/OptionsContext"
 import { CheckboxWithLabel } from "./util"
 import { Icon } from "@mdi/react"
 import { memo } from "react"
@@ -25,6 +25,8 @@ import {
   mdiPuzzle,
   mdiViewModule,
   mdiCog,
+  mdiFileTree,
+  mdiFamilyTree,
 } from "@mdi/js"
 import type { SizeMetricType } from "~/metrics/sizeMetric"
 import { SizeMetric } from "~/metrics/sizeMetric"
@@ -46,6 +48,7 @@ export const Options = memo(function Options() {
     chartType,
     depthType,
     sizeMetric,
+    hierarchyType,
     transitionsEnabled,
     setTransitionsEnabled,
     labelsVisible,
@@ -53,6 +56,7 @@ export const Options = memo(function Options() {
     setMetricType,
     setChartType,
     setDepthType,
+    setHierarchyType,
     setSizeMetricType,
   } = useOptions()
 
@@ -81,6 +85,11 @@ export const Options = memo(function Options() {
   const chartTypeIcons: Record<ChartType, string> = {
     BUBBLE_CHART: mdiChartBubble,
     TREE_MAP: mdiChartTree,
+  }
+
+  const hiearchyIcons: Record<HierarchyType, string> = {
+    NESTED: mdiFileTree,
+    FLAT: mdiChartTree,
   }
 
   const relatedSizeMetric: Record<MetricType, SizeMetricType> = {
@@ -148,16 +157,32 @@ export const Options = memo(function Options() {
         </fieldset>
         <fieldset className="rounded-lg border p-2">
           <legend className="card__title ml-1.5 justify-start gap-2">
-            <Icon path={mdiViewModule} size="1.25em" />
-            Depth
+            <Icon path={mdiFamilyTree} size="1.25em" />
+            Hiearchy
           </legend>
           <EnumSelect
-            enum={Depth}
-            defaultValue={depthType}
-            onChange={(depthType: DepthType) => setDepthType(depthType)}
-            iconMap={depthTypeIcons}
+            enum={Hierarchy}
+            defaultValue={hierarchyType}
+            onChange={(hiearchyType: HierarchyType) => {
+              return setHierarchyType(hiearchyType)
+            }}
+            iconMap={hiearchyIcons}
           />
         </fieldset>
+        {hierarchyType === "NESTED" ? (
+          <fieldset className="rounded-lg border p-2">
+            <legend className="card__title ml-1.5 justify-start gap-2">
+              <Icon path={mdiViewModule} size="1.25em" />
+              Depth
+            </legend>
+            <EnumSelect
+              enum={Depth}
+              defaultValue={depthType}
+              onChange={(depthType: DepthType) => setDepthType(depthType)}
+              iconMap={depthTypeIcons}
+            />
+          </fieldset>
+        ) : null}
         {/* </div> */}
 
         {/* 

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -4,7 +4,7 @@ import { ClickedObjectContext } from "~/contexts/ClickedContext"
 import type { RepoData } from "~/routes/$repo.$"
 import { DataContext } from "../contexts/DataContext"
 import { MetricsContext } from "../contexts/MetricContext"
-import type { ChartType, OptionsContextType } from "../contexts/OptionsContext"
+import type { ChartType, HierarchyType, OptionsContextType } from "../contexts/OptionsContext"
 import { getDefaultOptionsContextValue, OptionsContext } from "../contexts/OptionsContext"
 import { PathContext } from "../contexts/PathContext"
 import { SearchContext } from "../contexts/SearchContext"
@@ -45,6 +45,11 @@ export function Providers({ children, data }: ProvidersProps) {
         setOptions((prevOptions) => ({
           ...(prevOptions ?? getDefaultOptionsContextValue()),
           depthType,
+        })),
+      setHierarchyType: (hierarchyType: HierarchyType) =>
+        setOptions((prevOptions) => ({
+          ...(prevOptions ?? getDefaultOptionsContextValue()),
+          hierarchyType,
         })),
       setAuthorshipType: (authorshipType: AuthorshipType) =>
         setOptions((prevOptions) => ({

--- a/src/contexts/OptionsContext.ts
+++ b/src/contexts/OptionsContext.ts
@@ -12,11 +12,19 @@ export const Chart = {
 
 export type ChartType = keyof typeof Chart
 
+export const Hierarchy = {
+  NESTED: "Nested",
+  FLAT: "Flat",
+}
+
+export type HierarchyType = keyof typeof Hierarchy
+
 export type Options = {
   hasLoadedSavedOptions: boolean
   metricType: MetricType
   chartType: ChartType
-  depthType: DepthType,
+  depthType: DepthType
+  hierarchyType: HierarchyType
   sizeMetric: SizeMetricType
   authorshipType: AuthorshipType
   transitionsEnabled: boolean
@@ -31,6 +39,7 @@ export type OptionsContextType = Options & {
   setTransitionsEnabled: (transitionsEnabled: boolean) => void
   setLabelsVisible: (labelsVisible: boolean) => void
   setDepthType: (depthType: DepthType) => void
+  setHierarchyType: (hierarchyType: HierarchyType) => void
 }
 
 export const OptionsContext = createContext<OptionsContextType | undefined>(undefined)
@@ -48,6 +57,7 @@ const defaultOptions: Options = {
   metricType: Object.keys(Metric)[0] as MetricType,
   chartType: Object.keys(Chart)[0] as ChartType,
   depthType: Object.keys(Depth)[0] as DepthType,
+  hierarchyType: Object.keys(Hierarchy)[0] as HierarchyType,
   sizeMetric: Object.keys(SizeMetric)[0] as SizeMetricType,
   authorshipType: Object.keys(Authorship)[0] as AuthorshipType,
   transitionsEnabled: true,
@@ -72,6 +82,9 @@ export function getDefaultOptionsContextValue(savedOptions: Partial<Options> = {
     },
     setDepthType: () => {
       throw new Error("No DepthTypeSetter provided")
+    },
+    setHierarchyType: () => {
+      throw new Error("No HiearchyTypeSetter provided")
     },
     setTransitionsEnabled: () => {
       throw new Error("No transitionsEnabledSetter provided")

--- a/src/routes/$repo.$.tsx
+++ b/src/routes/$repo.$.tsx
@@ -1,6 +1,6 @@
 import { resolve } from "path"
 import type { Dispatch, SetStateAction } from "react"
-import { memo, useEffect, useRef, useState } from "react"
+import { Fragment, memo, useEffect, useRef, useState } from "react"
 import { useBoolean, useMouse } from "react-use"
 import type { ActionFunction, LoaderArgs } from "@remix-run/node"
 import { redirect } from "@remix-run/node"
@@ -32,6 +32,7 @@ import { useClient } from "~/hooks"
 import clsx from "clsx"
 import { Tooltip } from "~/components/Tooltip"
 import { createPortal } from "react-dom"
+import { hierarchy, treemap, treemapBinary } from "d3-hierarchy"
 
 let invalidateCache = false
 


### PR DESCRIPTION
This pull request adds a new option to show a view without any hierarchy.

![image](https://github.com/git-truck/git-truck/assets/1959615/524b7a8c-d145-4407-b4d2-e5ded7674204)

What are your thoughts on this view?

If you don't care about how the codebase is structured, it's helpful to remove the hierarchy and show all the files in the root level.

![image](https://github.com/git-truck/git-truck/assets/1959615/5a1cb8bb-3d9e-4f1c-a1a6-f99b12bb194b)
![image](https://github.com/git-truck/git-truck/assets/1959615/6ca953b8-0d3d-4ca7-b647-e6563511455c)

This is based on the idea from #430 by @hojelse 