### PR TITLE
Convert react spring animations to CSS transitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@mdi/js": "^7.3.67",
         "@mdi/react": "^1.6.1",
         "@playwright/test": "^1.39.0",
-        "@react-spring/web": "^9.7.3",
         "@remix-run/dev": "2.2.0",
         "@remix-run/eslint-config": "2.2.0",
         "@remix-run/express": "^2.2.0",
@@ -2527,71 +2526,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@react-spring/animated": {
-      "version": "9.7.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.3.tgz",
-      "integrity": "sha512-5CWeNJt9pNgyvuSzQH+uy2pvTg8Y4/OisoscZIR8/ZNLIOI+CatFBhGZpDGTF/OzdNFsAoGk3wiUYTwoJ0YIvw==",
-      "dev": true,
-      "dependencies": {
-        "@react-spring/shared": "~9.7.3",
-        "@react-spring/types": "~9.7.3"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-spring/core": {
-      "version": "9.7.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.3.tgz",
-      "integrity": "sha512-IqFdPVf3ZOC1Cx7+M0cXf4odNLxDC+n7IN3MDcVCTIOSBfqEcBebSv+vlY5AhM0zw05PDbjKrNmBpzv/AqpjnQ==",
-      "dev": true,
-      "dependencies": {
-        "@react-spring/animated": "~9.7.3",
-        "@react-spring/shared": "~9.7.3",
-        "@react-spring/types": "~9.7.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/react-spring/donate"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-spring/shared": {
-      "version": "9.7.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.3.tgz",
-      "integrity": "sha512-NEopD+9S5xYyQ0pGtioacLhL2luflh6HACSSDUZOwLHoxA5eku1UPuqcJqjwSD6luKjjLfiLOspxo43FUHKKSA==",
-      "dev": true,
-      "dependencies": {
-        "@react-spring/types": "~9.7.3"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-spring/types": {
-      "version": "9.7.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.3.tgz",
-      "integrity": "sha512-Kpx/fQ/ZFX31OtlqVEFfgaD1ACzul4NksrvIgYfIFq9JpDHFwQkMVZ10tbo0FU/grje4rcL4EIrjekl3kYwgWw==",
-      "dev": true
-    },
-    "node_modules/@react-spring/web": {
-      "version": "9.7.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.3.tgz",
-      "integrity": "sha512-BXt6BpS9aJL/QdVqEIX9YoUy8CE6TJrU0mNCqSoxdXlIeNcEBWOfIyE6B14ENNsyQKS3wOWkiJfco0tCr/9tUg==",
-      "dev": true,
-      "dependencies": {
-        "@react-spring/animated": "~9.7.3",
-        "@react-spring/core": "~9.7.3",
-        "@react-spring/shared": "~9.7.3",
-        "@react-spring/types": "~9.7.3"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@remix-run/dev": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@mdi/js": "^7.3.67",
     "@mdi/react": "^1.6.1",
     "@playwright/test": "^1.39.0",
-    "@react-spring/web": "^9.7.3",
     "@remix-run/dev": "2.2.0",
     "@remix-run/eslint-config": "2.2.0",
     "@remix-run/express": "^2.2.0",

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -150,12 +150,14 @@ export const Chart = memo(function Chart({
               {...createGroupHandlers(d, i === 0)}
             >
               {(numberOfDepthLevels === undefined || d.depth <= numberOfDepthLevels) && (
-                <Node key={d.data.path} d={d} isSearchMatch={Boolean(searchResults[d.data.path])} />
-              )}
-              {labelsVisible && (
-                <NodeText key={`text|${path}|${d.data.path}|${chartType}|${sizeMetric}`} d={d}>
-                  {collapseText({ d, isRoot: i === 0, path, displayText: d.data.name, chartType })}
-                </NodeText>
+                <>
+                  <Node key={d.data.path} d={d} isSearchMatch={Boolean(searchResults[d.data.path])} />
+                  {labelsVisible && (
+                    <NodeText key={`text|${path}|${d.data.path}|${chartType}|${sizeMetric}`} d={d}>
+                      {collapseText({ d, isRoot: i === 0, path, displayText: d.data.name, chartType })}
+                    </NodeText>
+                  )}
+                </>
               )}
             </g>
           )

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -1,4 +1,3 @@
-import { animated } from "@react-spring/web"
 import type { HierarchyCircularNode, HierarchyNode, HierarchyRectangularNode } from "d3-hierarchy"
 import { hierarchy, pack, treemap, treemapBinary } from "d3-hierarchy"
 import type { MouseEventHandler } from "react"
@@ -10,7 +9,7 @@ import type {
   HydratedGitTreeObject,
 } from "~/analyzer/model"
 import { useClickedObject } from "~/contexts/ClickedContext"
-import { useToggleableSpring, useComponentSize } from "~/hooks"
+import { useComponentSize } from "~/hooks"
 import {
   bubblePadding,
   estimatedLetterHeightForDirText,
@@ -260,7 +259,7 @@ function Path({
   className?: string
 }) {
   const [metricsData] = useMetrics()
-  const { chartType, metricType, authorshipType } = useOptions()
+  const { chartType, metricType, authorshipType, transitionsEnabled } = useOptions()
 
   const dProp = useMemo(() => {
     if (chartType === "BUBBLE_CHART") {
@@ -278,7 +277,7 @@ function Path({
     }
   }, [chartType, d])
 
-  const props = useToggleableSpring({
+  const props = {
     d: dProp,
     stroke: isSearchMatch ? searchMatchColor : "transparent",
     strokeWidth: "1px",
@@ -286,12 +285,13 @@ function Path({
     fill: isBlob(d.data)
       ? metricsData[authorshipType].get(metricType)?.colormap.get(d.data.path) ?? "grey"
       : "transparent",
-  })
+  }
 
   return (
-    <animated.path
+    <path
       {...props}
       className={clsx(className, {
+        "transition-all duration-500 ease-out": transitionsEnabled,
         "animate-stroke-pulse": isSearchMatch,
         "stroke-black/20": isTree(d.data),
       })}
@@ -312,30 +312,30 @@ function CircleText({
   const { authorshipType, metricType } = useOptions()
   const yOffset = isTree(d.data) ? circleTreeTextOffsetY : circleBlobTextOffsetY
 
-  const props = useToggleableSpring({
+  const props = {
     d: circlePathFromCircle(d.x, d.y + estimatedLetterHeightForDirText - 1, d.r - yOffset),
-  })
+  }
 
-  const textProps = useToggleableSpring({
+  const textProps = {
     fill: isBlob(d.data)
       ? getTextColorFromBackground(metricsData[authorshipType].get(metricType)?.colormap.get(d.data.path) ?? "#333")
       : "#333",
-  })
+  }
 
   return (
     <>
-      <animated.path {...props} id={d.data.path} className="pointer-events-none fill-none stroke-none" />
+      <path {...props} id={d.data.path} className="pointer-events-none fill-none stroke-none" />
       {isTree(d.data) ? (
-        <animated.text
+        <text
           className="pointer-events-none stroke-white stroke-[7px] font-mono text-sm font-bold"
           strokeLinecap="round"
         >
           <textPath startOffset="50%" dominantBaseline="central" textAnchor="middle" xlinkHref={`#${d.data.path}`}>
             {displayText}
           </textPath>
-        </animated.text>
+        </text>
       ) : null}
-      <animated.text {...textProps} className="pointer-events-none">
+      <text {...textProps} className="pointer-events-none">
         <textPath
           className={clsx("font-mono", className, {
             "text-sm font-bold": isTree(d.data),
@@ -348,7 +348,7 @@ function CircleText({
         >
           {displayText}
         </textPath>
-      </animated.text>
+      </text>
     </>
   )
 }
@@ -368,23 +368,23 @@ function RectText({
   const xOffset = isTree(d.data) ? treemapTreeTextOffsetX : treemapBlobTextOffsetX
   const yOffset = isTree(d.data) ? treemapTreeTextOffsetY : treemapBlobTextOffsetY
 
-  const props = useToggleableSpring({
+  const props = {
     x: d.x0 + xOffset,
     y: d.y0 + yOffset,
     fill: isBlob(d.data)
       ? getTextColorFromBackground(metricsData[authorshipType].get(metricType)?.colormap.get(d.data.path) ?? "#333")
       : "#333",
-  })
+  }
 
   return (
-    <animated.text
+    <text
       {...props}
       className={clsx("pointer-events-none", className, {
         "font-bold": isTree(d.data),
       })}
     >
       {displayText}
-    </animated.text>
+    </text>
   )
 }
 

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -45,7 +45,7 @@ export const Chart = memo(function Chart({
   const { searchResults } = useSearch()
   const size = useDeferredValue(rawSize)
   const { analyzerData } = useData()
-  const { chartType, sizeMetric, depthType, hierarchyType } = useOptions()
+  const { chartType, sizeMetric, depthType, hierarchyType, labelsVisible } = useOptions()
   const { path } = usePath()
   const { clickedObject, setClickedObject } = useClickedObject()
   const { setPath } = usePath()
@@ -72,20 +72,22 @@ export const Chart = memo(function Chart({
       numberOfDepthLevels = undefined
   }
 
+  const commit = useMemo(() => {
+    if (hierarchyType === "NESTED") return analyzerData.commit
+
+    return {
+      ...analyzerData.commit,
+      tree: {
+        ...analyzerData.commit.tree,
+        children: flatten(analyzerData.commit.tree),
+      },
+    }
+  }, [analyzerData.commit, hierarchyType])
+
   const nodes = useMemo(() => {
     if (size.width === 0 || size.height === 0) return []
-    const commit =
-      hierarchyType === "NESTED"
-        ? analyzerData.commit
-        : {
-            ...analyzerData.commit,
-            tree: {
-              ...analyzerData.commit.tree,
-              children: flatten(analyzerData.commit.tree),
-            },
-          }
     return createPartitionedHiearchy(commit, size, chartType, sizeMetric, path).descendants()
-  }, [size, hierarchyType, analyzerData.commit, chartType, sizeMetric, path])
+  }, [size, commit, chartType, sizeMetric, path])
 
   useEffect(() => {
     setHoveredObject(null)
@@ -122,6 +124,7 @@ export const Chart = memo(function Chart({
   return (
     <div className="relative grid place-items-center overflow-hidden" ref={ref}>
       <svg
+        key={`svg|${size.width}|${size.height}`}
         className={clsx("grid h-full w-full place-items-center", {
           "cursor-zoom-out": path.includes("/"),
         })}
@@ -136,18 +139,24 @@ export const Chart = memo(function Chart({
         }}
       >
         {nodes.map((d, i) => {
-          if (numberOfDepthLevels !== undefined && d.depth > numberOfDepthLevels) return null
           return (
             <g
-              className={clsx("hover:opacity-60", {
+              key={d.data.path}
+              className={clsx("transition-opacity hover:opacity-60", {
                 "cursor-pointer": i === 0,
                 "cursor-zoom-in": i > 0 && isTree(d.data),
                 "animate-blink": clickedObject?.path === d.data.path,
               })}
-              key={`${chartType}${d.data.path}`}
               {...createGroupHandlers(d, i === 0)}
             >
-              <Node isRoot={i === 0} d={d} isSearchMatch={Boolean(searchResults[d.data.path])} />
+              {(numberOfDepthLevels === undefined || d.depth <= numberOfDepthLevels) && (
+                <Node key={d.data.path} d={d} isSearchMatch={Boolean(searchResults[d.data.path])} />
+              )}
+              {labelsVisible && (
+                <NodeText key={`text|${path}|${d.data.path}|${chartType}|${sizeMetric}`} d={d}>
+                  {collapseText({ d, isRoot: i === 0, path, displayText: d.data.name, chartType })}
+                </NodeText>
+              )}
             </g>
           )
         })}
@@ -156,20 +165,86 @@ export const Chart = memo(function Chart({
   )
 })
 
-const Node = memo(function Node({
+function Node({ d, isSearchMatch }: { d: CircleOrRectHiearchyNode; isSearchMatch: boolean }) {
+  const [metricsData] = useMetrics()
+  const { chartType, metricType, authorshipType, transitionsEnabled } = useOptions()
+
+  const commonProps = useMemo(() => {
+    let props: JSX.IntrinsicElements["rect"] = {
+      stroke: isSearchMatch ? searchMatchColor : "transparent",
+      strokeWidth: "1px",
+      fill: isBlob(d.data)
+        ? metricsData[authorshipType].get(metricType)?.colormap.get(d.data.path) ?? "grey"
+        : "transparent",
+    }
+
+    if (chartType === "BUBBLE_CHART") {
+      const circleDatum = d as HierarchyCircularNode<HydratedGitObject>
+      props = {
+        ...props,
+        x: circleDatum.x - circleDatum.r,
+        y: circleDatum.y - circleDatum.r + estimatedLetterHeightForDirText - 1,
+        width: circleDatum.r * 2,
+        height: circleDatum.r * 2,
+        rx: circleDatum.r,
+        ry: circleDatum.r,
+      }
+    } else {
+      const datum = d as HierarchyRectangularNode<HydratedGitObject>
+
+      props = {
+        ...props,
+        x: datum.x0,
+        y: datum.y0,
+        width: datum.x1 - datum.x0,
+        height: datum.y1 - datum.y0,
+        rx: treemapNodeBorderRadius,
+        ry: treemapNodeBorderRadius,
+      }
+    }
+    return props
+  }, [d, isSearchMatch, metricsData, authorshipType, metricType, chartType])
+
+  return (
+    <rect
+      {...commonProps}
+      className={clsx({
+        "cursor-pointer": isBlob(d.data),
+        "transition-all duration-1000 ease-in-out": transitionsEnabled,
+        "animate-stroke-pulse": isSearchMatch,
+        "stroke-black/20": isTree(d.data),
+      })}
+    />
+  )
+}
+
+function collapseText({
   d,
   isRoot,
-  isSearchMatch,
+  path,
+  displayText,
+  chartType,
 }: {
   d: CircleOrRectHiearchyNode
   isRoot: boolean
-  isSearchMatch: boolean
-}) {
-  const { chartType, labelsVisible } = useOptions()
-  let showLabel = labelsVisible
-  const { path } = usePath()
-  let displayText = d.data.name
-  type textIsTooLongFunction = (text: string) => boolean
+  path: string
+  displayText: string
+  chartType: ChartType
+}): string | null {
+  let textIsTooLong: (text: string) => boolean
+  let textIsTooTall: (text: string) => boolean
+  if (chartType === "BUBBLE_CHART") {
+    const circleDatum = d as HierarchyCircularNode<HydratedGitObject>
+    textIsTooLong = (text: string) => circleDatum.r < 50 || circleDatum.r * Math.PI < text.length * estimatedLetterWidth
+    textIsTooTall = () => false
+  } else {
+    const datum = d as HierarchyRectangularNode<HydratedGitObject>
+    textIsTooLong = (text: string) => datum.x1 - datum.x0 < text.length * estimatedLetterWidth
+    textIsTooTall = (text: string) => {
+      const heightAvailable = datum.y1 - datum.y0 - (isBlob(d.data) ? treemapBlobTextOffsetY : treemapTreeTextOffsetY)
+      return heightAvailable < estimatedLetterHeightForDirText
+    }
+  }
 
   if (isRoot) {
     const pathSteps = path.split("/")
@@ -187,205 +262,89 @@ const Node = memo(function Node({
     displayText = dispSteps.slice(ds - 1).join("/")
   }
 
-  switch (chartType) {
-    case "BUBBLE_CHART":
-      const circleDatum = d as HierarchyCircularNode<HydratedGitObject>
-      collapseDisplayText_mut(
-        (text: string) => circleDatum.r < 50 || circleDatum.r * Math.PI < text.length * estimatedLetterWidth
-      )
-      break
-    case "TREE_MAP":
-      const rectDatum = d as HierarchyRectangularNode<HydratedGitObject>
-      const xOffset = isTree(d.data) ? treemapTreeTextOffsetX : treemapBlobTextOffsetX
-      const yOffset = isTree(d.data) ? treemapTreeTextOffsetY : treemapBlobTextOffsetY
-
-      collapseDisplayText_mut(
-        (_: string) => rectDatum.x1 - rectDatum.x0 - xOffset * 2 < displayText.length * estimatedLetterWidth,
-        (_: string) => rectDatum.y1 - rectDatum.y0 - yOffset < estimatedLetterHeightForDirText
-      )
-      break
-    default:
-      throw Error("Unknown chart type")
-  }
-
-  return (
-    <>
-      <Path
-        className={clsx({
-          "cursor-pointer": isBlob(d.data),
-        })}
-        d={d}
-        isSearchMatch={isSearchMatch}
-      />
-      {showLabel ? (
-        chartType === "BUBBLE_CHART" ? (
-          <CircleText d={d as HierarchyCircularNode<HydratedGitObject>} displayText={displayText} />
-        ) : (
-          <RectText
-            className="font-mono"
-            d={d as HierarchyRectangularNode<HydratedGitObject>}
-            displayText={displayText}
-          />
-        )
-      ) : null}
-    </>
-  )
-
-  function collapseDisplayText_mut(textIsTooLong: textIsTooLongFunction, textIsTooTall?: textIsTooLongFunction) {
+  if (textIsTooLong(displayText)) {
+    displayText = displayText.replace(/\/.+\//gm, "/.../")
     if (textIsTooLong(displayText)) {
-      displayText = displayText.replace(/\/.+\//gm, "/.../")
-      if (textIsTooLong(displayText)) {
-        showLabel = false
-      }
-    }
-
-    if (textIsTooTall && textIsTooTall(displayText)) {
-      displayText = displayText.replace(/\/.+\//gm, "/.../")
-
-      if (textIsTooTall(displayText)) {
-        showLabel = false
-      }
+      return null
     }
   }
-})
 
-function Path({
-  d,
-  isSearchMatch,
-  className = "",
-}: {
-  d: CircleOrRectHiearchyNode
-  isSearchMatch: boolean
-  className?: string
-}) {
-  const [metricsData] = useMetrics()
-  const { chartType, metricType, authorshipType, transitionsEnabled } = useOptions()
+  if (textIsTooTall && textIsTooTall(displayText)) {
+    displayText = displayText.replace(/\/.+\//gm, "/.../")
 
-  const dProp = useMemo(() => {
-    if (chartType === "BUBBLE_CHART") {
-      const datum = d as HierarchyCircularNode<HydratedGitObject>
-      return circlePathFromCircle(datum.x, datum.y + estimatedLetterHeightForDirText - 1, datum.r - 1)
-    } else {
-      const datum = d as HierarchyRectangularNode<HydratedGitObject>
-      return roundedRectPathFromRect(
-        datum.x0,
-        datum.y0,
-        datum.x1 - datum.x0,
-        datum.y1 - datum.y0,
-        treemapNodeBorderRadius
-      )
+    if (textIsTooTall(displayText)) {
+      return null
     }
-  }, [chartType, d])
-
-  const props = {
-    d: dProp,
-    stroke: isSearchMatch ? searchMatchColor : "transparent",
-    strokeWidth: "1px",
-
-    fill: isBlob(d.data)
-      ? metricsData[authorshipType].get(metricType)?.colormap.get(d.data.path) ?? "grey"
-      : "transparent",
   }
 
-  return (
-    <path
-      {...props}
-      className={clsx(className, {
-        "transition-all duration-500 ease-out": transitionsEnabled,
-        "animate-stroke-pulse": isSearchMatch,
-        "stroke-black/20": isTree(d.data),
-      })}
-    />
-  )
+  return displayText
 }
 
-function CircleText({
-  d,
-  displayText,
-  className = "",
-}: {
-  d: HierarchyCircularNode<HydratedGitObject>
-  displayText: string
-  className?: string
-}) {
+function NodeText({ d, children = null }: { d: CircleOrRectHiearchyNode; children?: React.ReactNode }) {
   const [metricsData] = useMetrics()
   const { authorshipType, metricType } = useOptions()
-  const yOffset = isTree(d.data) ? circleTreeTextOffsetY : circleBlobTextOffsetY
+  const isBubbleChart = isCircularNode(d)
 
-  const props = {
-    d: circlePathFromCircle(d.x, d.y + estimatedLetterHeightForDirText - 1, d.r - yOffset),
+  if (children === null) return null
+
+  let textPathData: string
+
+  if (isBubbleChart) {
+    const yOffset = isTree(d.data) ? circleTreeTextOffsetY : circleBlobTextOffsetY
+    const circleDatum = d as HierarchyCircularNode<HydratedGitObject>
+    textPathData = circlePathFromCircle(circleDatum.x, circleDatum.y + yOffset, circleDatum.r)
+  } else {
+    const datum = d as HierarchyRectangularNode<HydratedGitObject>
+    textPathData = roundedRectPathFromRect(
+      datum.x0 + (isTree(d.data) ? treemapTreeTextOffsetX : treemapBlobTextOffsetX),
+      datum.y0 + (isTree(d.data) ? treemapTreeTextOffsetY : treemapBlobTextOffsetY),
+      datum.x1 - datum.x0,
+      datum.y1 - datum.y0,
+      0
+    )
   }
 
-  const textProps = {
-    fill: isBlob(d.data)
-      ? getTextColorFromBackground(metricsData[authorshipType].get(metricType)?.colormap.get(d.data.path) ?? "#333")
-      : "#333",
+  const fillColor = isBlob(d.data)
+    ? getTextColorFromBackground(metricsData[authorshipType].get(metricType)?.colormap.get(d.data.path) ?? "#333")
+    : "#333"
+
+  const textPathBaseProps = {
+    startOffset: isBubbleChart ? "50%" : undefined,
+    dominantBaseline: isBubbleChart ? (isTree(d.data) ? "central" : "hanging") : "hanging",
+    textAnchor: isBubbleChart ? "middle" : "start",
+    href: `#path-${d.data.path}`,
   }
 
   return (
     <>
-      <path {...props} id={d.data.path} className="pointer-events-none fill-none stroke-none" />
+      <path d={textPathData} id={`path-${d.data.path}`} className="hidden" />
       {isTree(d.data) ? (
         <text
-          className="pointer-events-none stroke-white stroke-[7px] font-mono text-sm font-bold"
+          className={clsx("pointer-events-none fill-none stroke-[7px] font-mono text-sm font-bold", {
+            "stroke-white": isBubbleChart,
+          })}
           strokeLinecap="round"
         >
-          <textPath startOffset="50%" dominantBaseline="central" textAnchor="middle" xlinkHref={`#${d.data.path}`}>
-            {displayText}
-          </textPath>
+          <textPath {...textPathBaseProps}>{children}</textPath>
         </text>
       ) : null}
-      <text {...textProps} className="pointer-events-none">
+      <text fill={fillColor} className="pointer-events-none">
         <textPath
-          className={clsx("font-mono", className, {
+          {...textPathBaseProps}
+          className={clsx("font-mono", {
             "text-sm font-bold": isTree(d.data),
             "text-xs": !isTree(d.data),
           })}
-          startOffset="50%"
-          dominantBaseline="central"
-          textAnchor="middle"
-          xlinkHref={`#${d.data.path}`}
         >
-          {displayText}
+          {children}
         </textPath>
       </text>
     </>
   )
 }
 
-function RectText({
-  d,
-  displayText,
-  className = "",
-}: {
-  d: HierarchyRectangularNode<HydratedGitObject>
-  displayText: string
-  className?: string
-}) {
-  const [metricsData] = useMetrics()
-  const { authorshipType, metricType } = useOptions()
-
-  const xOffset = isTree(d.data) ? treemapTreeTextOffsetX : treemapBlobTextOffsetX
-  const yOffset = isTree(d.data) ? treemapTreeTextOffsetY : treemapBlobTextOffsetY
-
-  const props = {
-    x: d.x0 + xOffset,
-    y: d.y0 + yOffset,
-    fill: isBlob(d.data)
-      ? getTextColorFromBackground(metricsData[authorshipType].get(metricType)?.colormap.get(d.data.path) ?? "#333")
-      : "#333",
-  }
-
-  return (
-    <text
-      {...props}
-      className={clsx("pointer-events-none", className, {
-        "font-bold": isTree(d.data),
-      })}
-    >
-      {displayText}
-    </text>
-  )
+function isCircularNode(d: CircleOrRectHiearchyNode) {
+  return typeof (d as HierarchyCircularNode<HydratedGitObject>).r === "number"
 }
 
 function createPartitionedHiearchy(
@@ -415,23 +374,21 @@ function createPartitionedHiearchy(
 
   const castedTree = currentTree as HydratedGitObject
 
-  const hiearchy = hierarchy(castedTree)
-    .sum((d) => {
-      const hydratedBlob = d as HydratedGitBlobObject
-      switch (sizeMetricType) {
-        case "FILE_SIZE":
-          return hydratedBlob.sizeInBytes ?? 1
-        case "MOST_COMMITS":
-          return hydratedBlob.noCommits
-        case "EQUAL_SIZE":
-          return 1
-        case "LAST_CHANGED":
-          return (hydratedBlob.lastChangeEpoch ?? data.oldestLatestChangeEpoch) - data.oldestLatestChangeEpoch
-        case "TRUCK_FACTOR":
-          return Object.keys(hydratedBlob.authors ?? {}).length
-      }
-    })
-    .sort((a, b) => (b.value !== undefined && a.value !== undefined ? b.value - a.value : 0))
+  const hiearchy = hierarchy(castedTree).sum((d) => {
+    const hydratedBlob = d as HydratedGitBlobObject
+    switch (sizeMetricType) {
+      case "FILE_SIZE":
+        return hydratedBlob.sizeInBytes ?? 1
+      case "MOST_COMMITS":
+        return hydratedBlob.noCommits
+      case "EQUAL_SIZE":
+        return 1
+      case "LAST_CHANGED":
+        return (hydratedBlob.lastChangeEpoch ?? data.oldestLatestChangeEpoch) - data.oldestLatestChangeEpoch
+      case "TRUCK_FACTOR":
+        return Object.keys(hydratedBlob.authors ?? {}).length
+    }
+  })
 
   switch (chartType) {
     case "TREE_MAP":

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,12 +1,14 @@
-export const treemapPaddingTop = 20
-export const treemapNodeBorderRadius = 8
-export const treemapTreeTextOffsetX = 13
-export const treemapTreeTextOffsetY = 15
-export const treemapBlobTextOffsetX = 10
-export const treemapBlobTextOffsetY = 16
-export const bubblePadding = 10
-export const circleTreeTextOffsetY = 0
-export const circleBlobTextOffsetY = 10
-export const searchMatchColor = "red"
 export const estimatedLetterWidth = 10
 export const estimatedLetterHeightForDirText = 14
+
+export const treemapPaddingTop = 20
+export const treemapNodeBorderRadius = 8
+export const treemapTreeTextOffsetX = treemapNodeBorderRadius
+export const treemapTreeTextOffsetY = 3
+export const treemapBlobTextOffsetX = 4
+export const treemapBlobTextOffsetY = 3
+
+export const bubblePadding = 10
+export const circleTreeTextOffsetY = estimatedLetterHeightForDirText - 1
+export const circleBlobTextOffsetY = estimatedLetterHeightForDirText
+export const searchMatchColor = "red"

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,10 +1,7 @@
-import { useSpring } from "@react-spring/web"
 import type { MutableRefObject } from "react"
 import { useState } from "react"
 import { useEffect, useMemo } from "react"
-import { useBoolean } from "react-use"
 import { useComponentSize as useCompSize } from "react-use-size"
-import { useOptions } from "./contexts/OptionsContext"
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type RefAndSize = [MutableRefObject<any>, { width: number; height: number }]
@@ -13,19 +10,6 @@ export function useComponentSize() {
   const { ref, width, height } = useCompSize()
   const size: RefAndSize = useMemo(() => [ref, { width, height }], [ref, width, height])
   return size
-}
-
-export function useToggleableSpring(props: unknown) {
-  const { transitionsEnabled } = useOptions()
-  const [initialRender, setInitialRender] = useBoolean(true)
-  useEffect(() => {
-    setTimeout(() => setInitialRender(false), 0)
-  }, [setInitialRender])
-
-  return useSpring({
-    ...(typeof props === "object" ? props : {}),
-    immediate: initialRender || !transitionsEnabled,
-  })
 }
 
 export function useClient() {


### PR DESCRIPTION
This PR converts react spring animations to CSS transitions. It should be faster and have less overhead for the Chart component.

I tried recording it, but the video does not do it justice.

https://github.com/git-truck/git-truck/assets/1959615/320f1198-60f6-49db-80a7-9c91c5264b39


This PR also adds a transition between the tree map and the circle packing!

https://github.com/git-truck/git-truck/assets/1959615/9c1d5e6b-4c19-41dd-9fd3-b472df32d688

The performance is much improved, compared to the old implementation.

You can compare this and current GT like so:

```
npx git-truck@0.0.0-d21ce66
```

```
npx git-truck@latest
```

My testing has showed that the user experience is much smoother and snappier.

**Changes:**

- [x] Remove `@react-spring/web` dependency
- [x] Remove `useToggleableSpring` hook
- [x] Refactor Node rendering to always use `rect` (with varying corner radius)
  - [x] Circles have a corner radius of their radius
  - [x] Rectangles have a fixed corner radius of 8 pixels
- [x] Refactor to single NodeText that handles both labels for circles and rectangles
- [x] Adjust animation duration and [animation function](https://cubic-bezier.com/)

![image](https://github.com/git-truck/git-truck/assets/1959615/c0d13558-0383-445e-a8f1-cea6d832268f)


