### PR TITLE
Feature: Add filtering and sorting for Commits tab

### DIFF
--- a/src/components/CommitHistory.tsx
+++ b/src/components/CommitHistory.tsx
@@ -8,17 +8,16 @@ import Accordion from "./accordion/Accordion"
 import { useFetcher } from "@remix-run/react"
 import { useClickedObject } from "~/contexts/ClickedContext"
 import { useData } from "~/contexts/DataContext"
-
-type SortCommitsMethods = "date" | "author"
+import type { SortingMethodsType } from "~/contexts/OptionsContext"
 
 interface CommitDistFragProps {
   items: GitLogEntry[]
-  sortBy?: SortCommitsMethods
+  sortBy?: SortingMethodsType
   handleOnClick?: (commit: GitLogEntry) => void
 }
 
 function CommitDistFragment(props: CommitDistFragProps) {
-  const sortMethod: SortCommitsMethods = props.sortBy !== undefined ? props.sortBy : "date"
+  const sortMethod: SortingMethodsType = props.sortBy !== undefined ? props.sortBy : "DATE"
 
   const cleanGroupItems: { [key: string]: GitLogEntry[] } = sortCommits(props.items, sortMethod)
 
@@ -131,11 +130,9 @@ export function CommitHistory() {
     }
   }, [fetcher.data, fetcher.state])
 
-  const headerText = useMemo<string>(() => {
+  const footerText = useMemo<string>(() => {
     if (!clickedObject) return ""
-    return `Commit history (${Math.min(totalCommitHashes.length, commitIndex + commitIncrement)} of ${
-      totalCommitHashes.length
-    } shown)`
+    return `(${Math.min(totalCommitHashes.length, commitIndex + commitIncrement)} of ${totalCommitHashes.length} shown)`
   }, [clickedObject, totalCommitHashes, commitIndex])
 
   if (!clickedObject) return null
@@ -155,11 +152,6 @@ export function CommitHistory() {
 
   return (
     <>
-      <div className="flex cursor-pointer justify-between hover:opacity-70">
-        <label className="label grow">
-          <h3 className="font-bold">{headerText}</h3>
-        </label>
-      </div>
       <div>
         <CommitDistFragment items={commits} />
 
@@ -169,9 +161,11 @@ export function CommitHistory() {
               onClick={() => setCommitIndex(commitIndex + commitIncrement)}
               className="whitespace-pre text-xs font-medium opacity-70 hover:cursor-pointer"
             >
-              Load more commits
+              Load more commits {footerText}
             </span>
-          ) : null
+          ) : (
+            <span className="whitespace-pre text-xs font-medium opacity-70">{footerText}</span>
+          )
         ) : (
           <h3>Loading commits...</h3>
         )}

--- a/src/components/CommitHistory.tsx
+++ b/src/components/CommitHistory.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import type { GitLogEntry, HydratedGitTreeObject } from "~/analyzer/model"
-import { Fragment, useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { dateFormatLong } from "~/util"
 import commitIcon from "~/assets/commit_icon.png"
 import type { AccordionData } from "./accordion/Accordion"
@@ -8,16 +8,21 @@ import Accordion from "./accordion/Accordion"
 import { useFetcher } from "@remix-run/react"
 import { useClickedObject } from "~/contexts/ClickedContext"
 import { useData } from "~/contexts/DataContext"
-import type { SortingMethodsType } from "~/contexts/OptionsContext"
+import { SortingMethods, SortingOrders, useOptions } from "~/contexts/OptionsContext"
+import type { CommitSortingMethodsType } from "~/contexts/OptionsContext"
 
 interface CommitDistFragProps {
   items: GitLogEntry[]
-  sortBy?: SortingMethodsType
+  sortBy?: CommitSortingMethodsType
   handleOnClick?: (commit: GitLogEntry) => void
 }
 
 function CommitDistFragment(props: CommitDistFragProps) {
-  const sortMethod: SortingMethodsType = props.sortBy !== undefined ? props.sortBy : "DATE"
+  const sortMethod: CommitSortingMethodsType = props.sortBy !== undefined ? props.sortBy : "DATE"
+  const { commitSortingOrdersType, commitSortingMethodsType } = useOptions()
+  const isDateSortingMethod: boolean = commitSortingMethodsType == Object.keys(SortingMethods)[0]
+  const isDefaultSortingOrdersSelected: boolean =
+    commitSortingOrdersType == Object.keys(SortingOrders(isDateSortingMethod))[0]
 
   const cleanGroupItems: { [key: string]: GitLogEntry[] } = sortCommits(props.items, sortMethod)
 
@@ -51,7 +56,7 @@ function CommitDistFragment(props: CommitDistFragProps) {
       titleLabels={true}
       multipleOpen={true}
       openByDefault={true}
-      items={items}
+      items={isDefaultSortingOrdersSelected ? items : items.reverse()}
     />
   )
 }
@@ -86,6 +91,7 @@ export function CommitHistory() {
   const commitIncrement = 5
   const { clickedObject } = useClickedObject()
   const fetcher = useFetcher()
+  const { commitSortingMethodsType } = useOptions()
 
   function requestCommits(index: number, commitHashes?: string[]) {
     const searchParams = new URLSearchParams()
@@ -153,7 +159,7 @@ export function CommitHistory() {
   return (
     <>
       <div>
-        <CommitDistFragment items={commits} />
+        <CommitDistFragment items={commits} sortBy={commitSortingMethodsType} />
 
         {fetcher.state === "idle" ? (
           commitIndex + commitIncrement < totalCommitHashes.length ? (
@@ -174,10 +180,11 @@ export function CommitHistory() {
   )
 }
 
-function sortCommits(items: GitLogEntry[], method: SortCommitsMethods): { [key: string]: GitLogEntry[] } {
+function sortCommits(items: GitLogEntry[], method: CommitSortingMethodsType): { [key: string]: GitLogEntry[] } {
   const cleanGroupItems: { [key: string]: GitLogEntry[] } = {}
   switch (method) {
-    case "author":
+    // case AUTHOR
+    case Object.keys(SortingMethods)[1]:
       for (const commit of items) {
         const author: string = commit.author
         if (!cleanGroupItems[author]) {
@@ -186,7 +193,8 @@ function sortCommits(items: GitLogEntry[], method: SortCommitsMethods): { [key: 
         cleanGroupItems[author].push(commit)
       }
       break
-    case "date":
+    // case DATE
+    case Object.keys(SortingMethods)[0]:
     default:
       for (const commit of items) {
         const date: string = dateFormatLong(commit.time)

--- a/src/components/CommitHistory.tsx
+++ b/src/components/CommitHistory.tsx
@@ -91,7 +91,7 @@ export function CommitHistory() {
   const commitIncrement = 5
   const { clickedObject } = useClickedObject()
   const fetcher = useFetcher()
-  const { commitSortingMethodsType } = useOptions()
+  const { commitSortingMethodsType, commitSearch } = useOptions()
 
   function requestCommits(index: number, commitHashes?: string[]) {
     const searchParams = new URLSearchParams()
@@ -138,7 +138,9 @@ export function CommitHistory() {
 
   const footerText = useMemo<string>(() => {
     if (!clickedObject) return ""
-    return `(${Math.min(totalCommitHashes.length, commitIndex + commitIncrement)} of ${totalCommitHashes.length} shown)`
+    return `(${Math.min(totalCommitHashes.length, commitIndex + commitIncrement)} of ${
+      totalCommitHashes.length
+    } loaded)`
   }, [clickedObject, totalCommitHashes, commitIndex])
 
   if (!clickedObject) return null
@@ -159,7 +161,14 @@ export function CommitHistory() {
   return (
     <>
       <div>
-        <CommitDistFragment items={commits} sortBy={commitSortingMethodsType} />
+        <CommitDistFragment
+          items={
+            commitSearch != ""
+              ? commits.filter((commit: GitLogEntry) => commit.message.includes(commitSearch))
+              : commits
+          }
+          sortBy={commitSortingMethodsType}
+        />
 
         {fetcher.state === "idle" ? (
           commitIndex + commitIncrement < totalCommitHashes.length ? (

--- a/src/components/CommitHistory.tsx
+++ b/src/components/CommitHistory.tsx
@@ -164,7 +164,7 @@ export function CommitHistory() {
         <CommitDistFragment
           items={
             commitSearch != ""
-              ? commits.filter((commit: GitLogEntry) => commit.message.includes(commitSearch))
+              ? commits.filter((commit: GitLogEntry) => commit.message.toLowerCase().includes(commitSearch.toLowerCase()))
               : commits
           }
           sortBy={commitSortingMethodsType}

--- a/src/components/CommitSettings.tsx
+++ b/src/components/CommitSettings.tsx
@@ -17,12 +17,12 @@ import type { CommitSortingMethodsType, CommitSortingOrdersType } from "~/contex
 import { SortingMethods, SortingOrders, useOptions } from "~/contexts/OptionsContext"
 import { useId } from "react"
 
-const sortingMethodsIcons: Record<SortingMethodsType, string> = {
+const sortingMethodsIcons: Record<CommitSortingMethodsType, string> = {
   DATE: mdiCalendarRange,
   AUTHOR: mdiHuman
 }
 
-const sortingOrdersIcons: Record<CommitSortingOrdersType, string> = (isDate: boolean) => {
+function getSortingOrdersIcons(isDate: boolean): Record<CommitSortingOrdersType, string> {
   return {
     ASCENDING: isDate ? mdiSortCalendarAscending : mdiOrderAlphabeticalAscending,
     DESCENDING: isDate ? mdiSortCalendarDescending : mdiOrderAlphabeticalDescending
@@ -71,7 +71,7 @@ export function CommitSettings() {
             onChange={(sortingOrder: CommitSortingOrdersType) => {
               return setCommitSortingOrdersType(sortingOrder)
             }}
-            iconMap={sortingOrdersIcons(isDateSortingMethod)}
+            iconMap={getSortingOrdersIcons(isDateSortingMethod)}
           />
         </fieldset>
         <fieldset className="rounded-lg border p-2">

--- a/src/components/CommitSettings.tsx
+++ b/src/components/CommitSettings.tsx
@@ -1,0 +1,89 @@
+import Icon from "@mdi/react"
+import type { AccordionData } from "./accordion/Accordion"
+import Accordion from "./accordion/Accordion"
+import { EnumSelect } from "./EnumSelect"
+import {
+  mdiCalendarRange,
+  mdiHuman,
+  mdiOrderAlphabeticalAscending,
+  mdiOrderAlphabeticalDescending,
+  mdiOrderBoolAscending,
+  mdiSort,
+  mdiUpdate
+} from "@mdi/js"
+import type { SortingMethodsType, SortingOrdersType } from "~/contexts/OptionsContext"
+import { SortingMethods, SortingOrders } from "~/contexts/OptionsContext"
+
+const sortingMethodsIcons: Record<SortingMethodsType, string> = {
+  DATE: mdiCalendarRange,
+  AUTHOR: mdiHuman
+}
+
+const sortingOrdersIcons: Record<SortingOrdersType, string> = {
+  ASCENDING: mdiOrderAlphabeticalAscending,
+  DESCENDING: mdiOrderAlphabeticalDescending
+}
+
+export function CommitSettings() {
+  const sortingItems: Array<AccordionData> = new Array<AccordionData>()
+  const defaultSortingMethod = Object.keys(SortingMethods)[0] as SortingMethodsType
+  const defaultSortingOrder = Object.keys(SortingOrders(true))[0] as SortingOrdersType
+
+  sortingItems.push({
+    title: "Sorting and filtering",
+    content: (
+      <>
+        <fieldset className="rounded-lg border p-2">
+          <legend className="card__title ml-1.5 justify-start gap-2">
+            <Icon path={mdiSort} size="1.25em" />
+            Sorting
+          </legend>
+          <EnumSelect
+            enum={SortingMethods}
+            defaultValue={defaultSortingMethod}
+            onChange={(hiearchyType: SortingMethodsType) => {
+              console.log(hiearchyType)
+            }}
+            iconMap={sortingMethodsIcons}
+          />
+        </fieldset>
+        <fieldset className="rounded-lg border p-2">
+          <legend className="card__title ml-1.5 justify-start gap-2">
+            <Icon path={mdiOrderBoolAscending} size="1.25em" />
+            Sorting order
+          </legend>
+          <EnumSelect
+            enum={SortingOrders(true)}
+            defaultValue={defaultSortingOrder}
+            onChange={(sortingOrder: SortingOrdersType) => {
+              console.log(sortingOrder)
+            }}
+            iconMap={sortingOrdersIcons}
+          />
+        </fieldset>
+        <fieldset className="rounded-lg border p-2">
+          <legend className="card__title ml-1.5 justify-start gap-2">
+            <Icon path={mdiUpdate} size="1.25em" />
+            Dates
+          </legend>
+          <p className="mb-1">
+            From: <input type="date" />
+          </p>
+          <p>
+            To: <input type="date" />
+          </p>
+        </fieldset>
+      </>
+    )
+  })
+
+  return (
+    <Accordion
+      key={sortingItems.length > 0 ? sortingItems[0].title : new Date().toDateString()}
+      titleLabels={true}
+      multipleOpen={false}
+      openByDefault={false}
+      items={sortingItems}
+    />
+  )
+}

--- a/src/components/CommitSettings.tsx
+++ b/src/components/CommitSettings.tsx
@@ -4,17 +4,18 @@ import Accordion from "./accordion/Accordion"
 import { EnumSelect } from "./EnumSelect"
 import {
   mdiCalendarRange,
+  mdiChat,
   mdiHuman,
   mdiOrderAlphabeticalAscending,
   mdiOrderAlphabeticalDescending,
   mdiOrderBoolAscending,
   mdiSort,
   mdiSortCalendarAscending,
-  mdiSortCalendarDescending,
-  mdiUpdate
+  mdiSortCalendarDescending
 } from "@mdi/js"
 import type { CommitSortingMethodsType, CommitSortingOrdersType } from "~/contexts/OptionsContext"
 import { SortingMethods, SortingOrders, useOptions } from "~/contexts/OptionsContext"
+import { useId } from "react"
 
 const sortingMethodsIcons: Record<SortingMethodsType, string> = {
   DATE: mdiCalendarRange,
@@ -29,9 +30,16 @@ const sortingOrdersIcons: Record<CommitSortingOrdersType, string> = (isDate: boo
 }
 
 export function CommitSettings() {
+  const id = useId()
   const items: Array<AccordionData> = new Array<AccordionData>()
-  const { commitSortingMethodsType, commitSortingOrdersType, setCommitSortingMethodsType, setCommitSortingOrdersType } =
-    useOptions()
+  const {
+    commitSearch,
+    commitSortingMethodsType,
+    commitSortingOrdersType,
+    setCommitSearch,
+    setCommitSortingMethodsType,
+    setCommitSortingOrdersType
+  } = useOptions()
   const isDateSortingMethod: boolean = commitSortingMethodsType == Object.keys(SortingMethods)[0]
 
   items.push({
@@ -68,15 +76,20 @@ export function CommitSettings() {
         </fieldset>
         <fieldset className="rounded-lg border p-2">
           <legend className="card__title ml-1.5 justify-start gap-2">
-            <Icon path={mdiUpdate} size="1.25em" />
-            Dates
+            <Icon path={mdiChat} size="1.25em" />
+            Part of the message
           </legend>
-          <p className="mb-1">
-            From: <input type="date" />
-          </p>
-          <p>
-            To: <input type="date" />
-          </p>
+          <input
+            className="input"
+            id={id}
+            type="search"
+            placeholder="Search for a commit..."
+            value={commitSearch}
+            onChange={(event) => {
+              const value = event.target.value
+              setCommitSearch(value)
+            }}
+          />
         </fieldset>
       </>
     )

--- a/src/components/CommitSettings.tsx
+++ b/src/components/CommitSettings.tsx
@@ -9,27 +9,32 @@ import {
   mdiOrderAlphabeticalDescending,
   mdiOrderBoolAscending,
   mdiSort,
+  mdiSortCalendarAscending,
+  mdiSortCalendarDescending,
   mdiUpdate
 } from "@mdi/js"
-import type { SortingMethodsType, SortingOrdersType } from "~/contexts/OptionsContext"
-import { SortingMethods, SortingOrders } from "~/contexts/OptionsContext"
+import type { CommitSortingMethodsType, CommitSortingOrdersType } from "~/contexts/OptionsContext"
+import { SortingMethods, SortingOrders, useOptions } from "~/contexts/OptionsContext"
 
 const sortingMethodsIcons: Record<SortingMethodsType, string> = {
   DATE: mdiCalendarRange,
   AUTHOR: mdiHuman
 }
 
-const sortingOrdersIcons: Record<SortingOrdersType, string> = {
-  ASCENDING: mdiOrderAlphabeticalAscending,
-  DESCENDING: mdiOrderAlphabeticalDescending
+const sortingOrdersIcons: Record<CommitSortingOrdersType, string> = (isDate: boolean) => {
+  return {
+    ASCENDING: isDate ? mdiSortCalendarAscending : mdiOrderAlphabeticalAscending,
+    DESCENDING: isDate ? mdiSortCalendarDescending : mdiOrderAlphabeticalDescending
+  }
 }
 
 export function CommitSettings() {
-  const sortingItems: Array<AccordionData> = new Array<AccordionData>()
-  const defaultSortingMethod = Object.keys(SortingMethods)[0] as SortingMethodsType
-  const defaultSortingOrder = Object.keys(SortingOrders(true))[0] as SortingOrdersType
+  const items: Array<AccordionData> = new Array<AccordionData>()
+  const { commitSortingMethodsType, commitSortingOrdersType, setCommitSortingMethodsType, setCommitSortingOrdersType } =
+    useOptions()
+  const isDateSortingMethod: boolean = commitSortingMethodsType == Object.keys(SortingMethods)[0]
 
-  sortingItems.push({
+  items.push({
     title: "Sorting and filtering",
     content: (
       <>
@@ -40,9 +45,9 @@ export function CommitSettings() {
           </legend>
           <EnumSelect
             enum={SortingMethods}
-            defaultValue={defaultSortingMethod}
-            onChange={(hiearchyType: SortingMethodsType) => {
-              console.log(hiearchyType)
+            defaultValue={commitSortingMethodsType}
+            onChange={(sortingMethodType: CommitSortingMethodsType) => {
+              return setCommitSortingMethodsType(sortingMethodType)
             }}
             iconMap={sortingMethodsIcons}
           />
@@ -53,12 +58,12 @@ export function CommitSettings() {
             Sorting order
           </legend>
           <EnumSelect
-            enum={SortingOrders(true)}
-            defaultValue={defaultSortingOrder}
-            onChange={(sortingOrder: SortingOrdersType) => {
-              console.log(sortingOrder)
+            enum={SortingOrders(isDateSortingMethod)}
+            defaultValue={commitSortingOrdersType}
+            onChange={(sortingOrder: CommitSortingOrdersType) => {
+              return setCommitSortingOrdersType(sortingOrder)
             }}
-            iconMap={sortingOrdersIcons}
+            iconMap={sortingOrdersIcons(isDateSortingMethod)}
           />
         </fieldset>
         <fieldset className="rounded-lg border p-2">
@@ -79,11 +84,11 @@ export function CommitSettings() {
 
   return (
     <Accordion
-      key={sortingItems.length > 0 ? sortingItems[0].title : new Date().toDateString()}
+      key={items.length > 0 ? items[0].title : new Date().toDateString()}
       titleLabels={true}
       multipleOpen={false}
       openByDefault={false}
-      items={sortingItems}
+      items={items}
     />
   )
 }

--- a/src/components/CommitsCard.tsx
+++ b/src/components/CommitsCard.tsx
@@ -1,13 +1,15 @@
-import { useClickedObject } from "~/contexts/ClickedContext"
 import { CommitHistory } from "./CommitHistory"
+import { CommitSettings } from "./CommitSettings"
 
 export function CommitsCard() {
-  const { clickedObject } = useClickedObject()
-  if (!clickedObject) return null
-
   return (
-    <div className="card bg-white/70 text-black">
-      <CommitHistory />
-    </div>
+    <>
+      <div className="card mb-2 bg-white/70 text-black">
+        <CommitSettings />
+      </div>
+      <div className="card bg-white/70 text-black">
+        <CommitHistory />
+      </div>
+    </>
   )
 }

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -93,6 +93,11 @@ export function Providers({ children, data }: ProvidersProps) {
           ...(prevOptions ?? getDefaultOptionsContextValue()),
           commitSortingOrdersType
         })),
+      setCommitSearch: (commitSearch: string) =>
+        setOptions((prevOptions) => ({
+          ...(prevOptions ?? getDefaultOptionsContextValue()),
+          commitSearch
+        })),
       setAuthorshipType: (authorshipType: AuthorshipType) =>
         setOptions((prevOptions) => ({
           ...(prevOptions ?? getDefaultOptionsContextValue()),

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -4,7 +4,13 @@ import { ClickedObjectContext } from "~/contexts/ClickedContext"
 import type { RepoData } from "~/routes/$repo.$"
 import { DataContext } from "../contexts/DataContext"
 import { MetricsContext } from "../contexts/MetricContext"
-import type { ChartType, HierarchyType, OptionsContextType } from "../contexts/OptionsContext"
+import type {
+  ChartType,
+  CommitSortingMethodsType,
+  CommitSortingOrdersType,
+  HierarchyType,
+  OptionsContextType
+} from "../contexts/OptionsContext"
 import { getDefaultOptionsContextValue, OptionsContext } from "../contexts/OptionsContext"
 import { PathContext } from "../contexts/PathContext"
 import { SearchContext } from "../contexts/SearchContext"
@@ -77,6 +83,16 @@ export function Providers({ children, data }: ProvidersProps) {
           ...(prevOptions ?? getDefaultOptionsContextValue()),
           hierarchyType
         })),
+      setCommitSortingMethodsType: (commitSortingMethodsType: CommitSortingMethodsType) =>
+        setOptions((prevOptions) => ({
+          ...(prevOptions ?? getDefaultOptionsContextValue()),
+          commitSortingMethodsType
+        })),
+      setCommitSortingOrdersType: (commitSortingOrdersType: CommitSortingOrdersType) =>
+        setOptions((prevOptions) => ({
+          ...(prevOptions ?? getDefaultOptionsContextValue()),
+          commitSortingOrdersType
+        })),
       setAuthorshipType: (authorshipType: AuthorshipType) =>
         setOptions((prevOptions) => ({
           ...(prevOptions ?? getDefaultOptionsContextValue()),
@@ -108,7 +124,7 @@ export function Providers({ children, data }: ProvidersProps) {
         setOptions((prevOptions) => ({
           ...(prevOptions ?? getDefaultOptionsContextValue()),
           renderCutoff: renderCutoff
-        })),
+        }))
     }),
     [options]
   )

--- a/src/contexts/OptionsContext.ts
+++ b/src/contexts/OptionsContext.ts
@@ -22,16 +22,15 @@ export const SortingMethods = {
   DATE: "By date",
   AUTHOR: "By author"
 }
-export type SortingMethodsType = keyof typeof SortingMethods
+export type CommitSortingMethodsType = keyof typeof SortingMethods
 
 export const SortingOrders = (isDate: boolean) => {
   return {
-    ASCENDING: isDate ? "Older first" : "Ascending",
-    DESCENDING: isDate ? "Latest first" : "Descending"
+    ASCENDING: isDate ? "Latest first" : "Ascending",
+    DESCENDING: isDate ? "Oldest first" : "Descending"
   }
 }
-
-export type SortingOrdersType = keyof typeof SortingOrders
+export type CommitSortingOrdersType = keyof typeof SortingOrders
 
 export type Options = {
   hasLoadedSavedOptions: boolean
@@ -39,6 +38,8 @@ export type Options = {
   chartType: ChartType
   depthType: DepthType
   hierarchyType: HierarchyType
+  commitSortingMethodsType: CommitSortingMethodsType
+  commitSortingOrdersType: CommitSortingOrdersType
   sizeMetric: SizeMetricType
   authorshipType: AuthorshipType
   transitionsEnabled: boolean
@@ -55,6 +56,8 @@ export type OptionsContextType = Options & {
   setLabelsVisible: (labelsVisible: boolean) => void
   setDepthType: (depthType: DepthType) => void
   setHierarchyType: (hierarchyType: HierarchyType) => void
+  setCommitSortingMethodsType: (commitSortingMethodsType: CommitSortingMethodsType) => void
+  setCommitSortingOrdersType: (commitSortingOrdersType: CommitSortingOrdersType) => void
   setRenderCutoff: (renderCutoff: number) => void
 }
 
@@ -76,6 +79,9 @@ const defaultOptions: Options = {
   hierarchyType: Object.keys(Hierarchy)[0] as HierarchyType,
   sizeMetric: Object.keys(SizeMetric)[0] as SizeMetricType,
   authorshipType: Object.keys(Authorship)[0] as AuthorshipType,
+  commitSortingMethodsType: Object.keys(SortingMethods)[0] as CommitSortingMethodsType,
+  // The parameter value is based on default sorting method - date (true) or author (false)
+  commitSortingOrdersType: Object.keys(SortingOrders(true))[0] as CommitSortingOrdersType,
   transitionsEnabled: true,
   labelsVisible: true,
   renderCutoff: 2
@@ -102,6 +108,12 @@ export function getDefaultOptionsContextValue(savedOptions: Partial<Options> = {
     },
     setHierarchyType: () => {
       throw new Error("No HiearchyTypeSetter provided")
+    },
+    setCommitSortingMethodsType: () => {
+      throw new Error("No CommitSortingMethodsTypeSetter provided")
+    },
+    setCommitSortingOrdersType: () => {
+      throw new Error("No CommitSortingOrdersTypeSetter provided")
     },
     setTransitionsEnabled: () => {
       throw new Error("No transitionsEnabledSetter provided")

--- a/src/contexts/OptionsContext.ts
+++ b/src/contexts/OptionsContext.ts
@@ -16,8 +16,22 @@ export const Hierarchy = {
   NESTED: "Nested",
   FLAT: "Flat"
 }
-
 export type HierarchyType = keyof typeof Hierarchy
+
+export const SortingMethods = {
+  DATE: "By date",
+  AUTHOR: "By author"
+}
+export type SortingMethodsType = keyof typeof SortingMethods
+
+export const SortingOrders = (isDate: boolean) => {
+  return {
+    ASCENDING: isDate ? "Older first" : "Ascending",
+    DESCENDING: isDate ? "Latest first" : "Descending"
+  }
+}
+
+export type SortingOrdersType = keyof typeof SortingOrders
 
 export type Options = {
   hasLoadedSavedOptions: boolean

--- a/src/contexts/OptionsContext.ts
+++ b/src/contexts/OptionsContext.ts
@@ -40,6 +40,7 @@ export type Options = {
   hierarchyType: HierarchyType
   commitSortingMethodsType: CommitSortingMethodsType
   commitSortingOrdersType: CommitSortingOrdersType
+  commitSearch: string
   sizeMetric: SizeMetricType
   authorshipType: AuthorshipType
   transitionsEnabled: boolean
@@ -58,6 +59,7 @@ export type OptionsContextType = Options & {
   setHierarchyType: (hierarchyType: HierarchyType) => void
   setCommitSortingMethodsType: (commitSortingMethodsType: CommitSortingMethodsType) => void
   setCommitSortingOrdersType: (commitSortingOrdersType: CommitSortingOrdersType) => void
+  setCommitSearch: (commitSearch: string) => void
   setRenderCutoff: (renderCutoff: number) => void
 }
 
@@ -82,6 +84,7 @@ const defaultOptions: Options = {
   commitSortingMethodsType: Object.keys(SortingMethods)[0] as CommitSortingMethodsType,
   // The parameter value is based on default sorting method - date (true) or author (false)
   commitSortingOrdersType: Object.keys(SortingOrders(true))[0] as CommitSortingOrdersType,
+  commitSearch: "",
   transitionsEnabled: true,
   labelsVisible: true,
   renderCutoff: 2
@@ -114,6 +117,9 @@ export function getDefaultOptionsContextValue(savedOptions: Partial<Options> = {
     },
     setCommitSortingOrdersType: () => {
       throw new Error("No CommitSortingOrdersTypeSetter provided")
+    },
+    setCommitSearch: () => {
+      throw new Error("No CommitSearchSetter provided")
     },
     setTransitionsEnabled: () => {
       throw new Error("No transitionsEnabledSetter provided")


### PR DESCRIPTION
# Problem

Currently, there is no interaction with commits in the `Commits` but we can easily add it. 

Current state:
![image](https://github.com/git-truck/git-truck/assets/52498300/6988b548-286c-4806-a56d-b8653d14ae2a)

# Solution

I added another card where I put the sort by option, sorting order and filtering by a part of a commit message. After my changes, it looks like this:
![image](https://github.com/git-truck/git-truck/assets/52498300/ed0690eb-dd5b-42d1-8b3c-c6aaeba04e37)

Resolves #677 