### PR TITLE
Fix crash in Safari

### DIFF
--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -138,10 +138,14 @@ export function Providers({ children, data }: ProvidersProps) {
     let canceled = false
     // Persist options to local storage
     if (options) {
-      requestIdleCallback(() => {
-        if (canceled) return
+      if (typeof requestIdleCallback === "function") {
+        requestIdleCallback(() => {
+          if (canceled) return
+          localStorage.setItem(OPTIONS_LOCAL_STORAGE_KEY, JSON.stringify(options))
+        })
+      } else {
         localStorage.setItem(OPTIONS_LOCAL_STORAGE_KEY, JSON.stringify(options))
-      })
+      }
     }
     return () => {
       canceled = true


### PR DESCRIPTION
This pull request fixes the crash issue in Safari that was reported in issue #736. The crash was caused by a problem with persisting options to local storage. The fix ensures that the options are properly persisted, preventing the crash from occurring.