### PR TITLE
Fix hide file buttons in details card not being routed correctly

### DIFF
--- a/src/routes/view.details.tsx
+++ b/src/routes/view.details.tsx
@@ -102,7 +102,7 @@ export default function Details() {
         </Link>
         {isBlob ? (
           <>
-            <Form className="w-max" method="post">
+            <Form className="w-max" method="post" action={viewAction}>
               <input type="hidden" name="hide" value={clickedObject.path} />
               <button className="btn" disabled={state !== "idle"} title="Hide this file">
                 <Icon path={mdiEyeOffOutline} />
@@ -110,7 +110,7 @@ export default function Details() {
               </button>
             </Form>
             {clickedObject.name.includes(".") ? (
-              <Form className="w-max" method="post">
+              <Form className="w-max" method="post" action={viewAction}>
                 <input type="hidden" name="hide" value={`*.${extension}`} />
                 <button
                   className="btn"


### PR DESCRIPTION
- [X] Hide files buttons in detail-card now functions as intended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form submission handling in the file details view to ensure proper routing of form actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->