### PR TITLE
Add support for co-authors

### DIFF
--- a/src/analyzer/DB.server.ts
+++ b/src/analyzer/DB.server.ts
@@ -876,18 +876,16 @@ export default class DB {
   }
 
   public async updateColorSeed(seed: string) {
-    await this.run(
-      `DELETE FROM metadata
+    await this.run(`DELETE FROM metadata
        WHERE field = 'colorSeed';
-       INSERT INTO metadata (field, stringValue)
-       VALUES ('colorSeed', '${seed}');`
-    )
+       INSERT INTO metadata (field, value, value2) 
+       VALUES ('colorSeed', null, '${seed}');`)
     log.debug("inserted seed", seed)
   }
 
   public async getColorSeed() {
     const res = await this.query(`
-      SELECT value2 FROM metadata WHERE field = 'colorseed';
+      SELECT value2 FROM metadata WHERE field = 'colorSeed';
     `)
     if (res.length < 1) return null
     log.debug("retrieved seed", res[0]["value2"])

--- a/src/analyzer/DB.server.ts
+++ b/src/analyzer/DB.server.ts
@@ -599,21 +599,36 @@ export default class DB {
   }
 
   public async getTopContributorPerFile() {
-    const res = await this.query(`
-      WITH RankedAuthors AS (
-        SELECT filePath, author, SUM(insertions + deletions) AS totalContribCount,
-        ROW_NUMBER() OVER (PARTITION BY filePath ORDER BY SUM(insertions + deletions) DESC, author ASC) AS rank
-        FROM fileChanges_commits_renamed_cached
-        GROUP BY filePath, author
+    const res = await this.query(/*sql*/ `
+      WITH commit_contributors AS (
+        SELECT f.filePath, f.commitHash, f.author AS contributor, (f.insertions + f.deletions) AS lineChanges
+        FROM fileChanges_commits_renamed_cached AS f
+        UNION
+        SELECT f.filePath, f.commitHash, co.name AS contributor, (f.insertions + f.deletions) AS lineChanges
+        FROM fileChanges_commits_renamed_cached AS f
+        INNER JOIN commitTrailers_unioned AS co ON f.commitHash = co.commitHash
+        WHERE co.trailerType = 'coauthor' AND (co.name <> f.author)
+      ),
+      ranked_contributors AS (
+        SELECT
+          filePath,
+          contributor,
+          SUM(lineChanges) AS totalContribCount,
+          ROW_NUMBER() OVER (
+            PARTITION BY filePath
+            ORDER BY SUM(lineChanges) DESC, contributor ASC
+          ) AS rank
+        FROM commit_contributors
+        GROUP BY filePath, contributor
       )
-      SELECT filePath, author, totalContribCount
-      FROM RankedAuthors
+      SELECT filePath, contributor, totalContribCount
+      FROM ranked_contributors
       WHERE rank = 1;
     `)
 
     const result: Record<string, { contributor: string; contribcount: number }> = {}
     res.forEach((row) => {
-      const contributor = row["author"]
+      const contributor = row["contributor"]
       if (typeof contributor !== "string") {
         throw new Error("Error when getting top contributor per file: Contributor is not a string")
       }

--- a/src/analyzer/DB.server.ts
+++ b/src/analyzer/DB.server.ts
@@ -548,20 +548,71 @@ export default class DB {
 
   public async getUniqueContributorsForPath(objectPath: string): Promise<string[]> {
     //Respects aliases for contributors through commits_unioned view
-    const res = await this.query(/*sql*/ `
+    const isblob = (await this.getObjectType(objectPath)) === "blob"
+    let res: ReturnType<DuckDBResultReader["getRowObjects"]>
+
+    if (isblob) {
+      res = await this.usingPreparedStatement(
+        /*sql*/ `
       WITH file_contributors AS (
         SELECT f.filePath, f.author AS contributor
         FROM filechanges_commits_renamed_cached AS f
-        WHERE f.filePath GLOB '${objectPath}*'
+        WHERE f.filePath = ?
         UNION
         SELECT f.filePath, ca.name AS contributor
         FROM filechanges_commits_renamed_cached AS f
         JOIN commitTrailers_unioned AS ca ON f.commitHash = ca.commitHash
-        WHERE ca.trailerType = 'coauthor' AND f.filePath GLOB '${objectPath}*'
+        WHERE ca.trailerType = 'coauthor' AND f.filePath = ?
+      )
+      SELECT DISTINCT contributor
+      FROM file_contributors;
+    `,
+        async (statement) => {
+          statement.bindVarchar(1, objectPath)
+          statement.bindVarchar(2, objectPath)
+          return (await statement.runAndReadAll()).getRowObjects()
+        },
+        "getUniqueContributorsForPath(blob)"
+      )
+    } else if (objectPath) {
+      res = await this.usingPreparedStatement(
+        /*sql*/ `
+      WITH file_contributors AS (
+        SELECT f.filePath, f.author AS contributor
+        FROM filechanges_commits_renamed_cached AS f
+        WHERE f.filePath LIKE ?
+        UNION
+        SELECT f.filePath, ca.name AS contributor
+        FROM filechanges_commits_renamed_cached AS f
+        JOIN commitTrailers_unioned AS ca ON f.commitHash = ca.commitHash
+        WHERE ca.trailerType = 'coauthor' AND f.filePath LIKE ?
+      )
+      SELECT DISTINCT contributor
+      FROM file_contributors;
+    `,
+        async (statement) => {
+          statement.bindVarchar(1, `${objectPath}/%`)
+          statement.bindVarchar(2, `${objectPath}/%`)
+          return (await statement.runAndReadAll()).getRowObjects()
+        },
+        "getUniqueContributorsForPath(tree)"
+      )
+    } else {
+      res = await this.query(/*sql*/ `
+      WITH file_contributors AS (
+        SELECT f.filePath, f.author AS contributor
+        FROM filechanges_commits_renamed_cached AS f
+        UNION
+        SELECT f.filePath, ca.name AS contributor
+        FROM filechanges_commits_renamed_cached AS f
+        JOIN commitTrailers_unioned AS ca ON f.commitHash = ca.commitHash
+        WHERE ca.trailerType = 'coauthor'
       )
       SELECT DISTINCT contributor
       FROM file_contributors;
     `)
+    }
+
     return res.map((row) => row["contributor"] as string)
   }
 

--- a/src/analyzer/DB.server.ts
+++ b/src/analyzer/DB.server.ts
@@ -147,6 +147,12 @@ export default class DB {
         deletions UINTEGER,
         filePath VARCHAR,
       );
+      CREATE TABLE IF NOT EXISTS commitTrailers (
+        commitHash VARCHAR,
+        name VARCHAR,
+        email VARCHAR,
+        trailerType VARCHAR
+      );
       CREATE TABLE IF NOT EXISTS contributorGroups (
         displayName VARCHAR,
         email VARCHAR,
@@ -194,6 +200,7 @@ export default class DB {
     await this.run(`
       DELETE FROM commits;
       DELETE FROM fileChanges;
+      DELETE FROM commitTrailers;
       DELETE FROM contributorGroups;
       DELETE FROM renames;
       DELETE FROM hiddenFiles;
@@ -658,8 +665,15 @@ export default class DB {
   }
 
   public async getAuthors() {
-    const res = await this.query(`SELECT DISTINCT author, authorEmail AS email
-      FROM commits;
+    const res = await this.query(`SELECT DISTINCT author, email
+      FROM (
+        SELECT c.author AS author, c.authorEmail AS email
+        FROM commits AS c
+        UNION
+        SELECT co.name AS author, co.email AS email
+        FROM commitTrailers AS co
+        WHERE co.trailerType = 'coauthor'
+      );
     `)
     return res.map((row) => ({
       name: String(row["author"] ?? ""),
@@ -863,6 +877,19 @@ export default class DB {
         appender.appendUInteger(commit.committerTime)
         appender.appendUInteger(commit.authorTime)
         appender.endRow()
+      }
+    })
+
+    await this.usingTableAppender("commitTrailers", async (appender) => {
+      for (const [hash, commit] of commits) {
+        if (!commit) throw new Error(`Commit with hash ${hash} is undefined`)
+        for (const coauthor of commit.coauthors) {
+          appender.appendVarchar(hash)
+          appender.appendVarchar(coauthor.name)
+          appender.appendVarchar(coauthor.email)
+          appender.appendVarchar("coauthor")
+          appender.endRow()
+        }
       }
     })
 

--- a/src/analyzer/DB.server.ts
+++ b/src/analyzer/DB.server.ts
@@ -754,48 +754,113 @@ export default class DB {
     return result
   }
 
+  public async getLineChangesSumForPath(objectPath: string): Promise<number> {
+    const isblob = (await this.getObjectType(objectPath)) === "blob"
+    let res: number
+
+    if (isblob) {
+      res = await this.usingPreparedStatement(
+        `SELECT SUM(insertions + deletions) AS lineChanges FROM fileChanges_commits_renamed_cached WHERE filePath = ?;`,
+        async (statement) => {
+          statement.bindVarchar(1, objectPath)
+          const results = (await statement.runAndReadAll()).getRowObjectsJS() as Array<{ lineChanges: number | bigint }>
+          return Number(results[0]?.lineChanges ?? 0)
+        },
+        "getLineChangesSumForPath(blob)"
+      )
+    } else if (objectPath) {
+      res = await this.usingPreparedStatement(
+        `SELECT SUM(insertions + deletions) AS lineChanges FROM fileChanges_commits_renamed_cached WHERE filePath LIKE ?;`,
+        async (statement) => {
+          statement.bindVarchar(1, `${objectPath}/%`)
+          const results = (await statement.runAndReadAll()).getRowObjectsJS() as Array<{ lineChanges: number | bigint }>
+          return Number(results[0]?.lineChanges ?? 0)
+        },
+        "getLineChangesSumForPath(tree)"
+      )
+    } else {
+      res = await this.query(
+        `SELECT SUM(insertions + deletions) AS lineChanges FROM fileChanges_commits_renamed_cached;`
+      ).then((results) => Number(results[0]?.lineChanges ?? 0))
+    }
+    return res
+  }
+
   public async getContributorDistributionForPath(objectPath: string) {
     const isblob = (await this.getObjectType(objectPath)) === "blob"
     let res: ReturnType<DuckDBResultReader["getRowObjects"]>
 
     if (isblob) {
       res = await this.usingPreparedStatement(
-        `SELECT author, SUM(insertions + deletions) AS contribSum
-         FROM fileChanges_commits_renamed_cached
-         WHERE filePath = ?
-         GROUP BY author
-         ORDER BY contribSum DESC, author ASC;`,
+        `WITH commit_contributors AS (
+          SELECT f.filePath, f.commitHash, f.author AS contributor, (f.insertions + f.deletions) AS lineChanges
+          FROM fileChanges_commits_renamed_cached AS f
+          WHERE f.filePath = ?
+          UNION
+          SELECT f.filePath, f.commitHash, co.name AS contributor, (f.insertions + f.deletions) AS lineChanges
+          FROM fileChanges_commits_renamed_cached AS f
+          INNER JOIN commitTrailers_unioned AS co ON f.commitHash = co.commitHash
+          WHERE f.filePath = ? AND co.trailerType = 'coauthor' AND co.name <> f.author
+        )
+        SELECT contributor, SUM(lineChanges) AS totalContribCount
+        FROM commit_contributors
+        GROUP BY contributor
+        ORDER BY totalContribCount DESC, contributor ASC;
+       `,
         async (statement) => {
           statement.bindVarchar(1, objectPath)
+          statement.bindVarchar(2, objectPath)
           return (await statement.runAndReadAll()).getRowObjects()
         },
         "getContributorDistributionForPath(blob)"
       )
     } else if (objectPath) {
       res = await this.usingPreparedStatement(
-        `SELECT author, SUM(insertions + deletions) AS contribSum
-         FROM fileChanges_commits_renamed_cached
-         WHERE filePath = ? OR filePath LIKE ?
-         GROUP BY author
-         ORDER BY contribSum DESC, author ASC;`,
+        `WITH commit_contributors AS (
+          SELECT f.filePath, f.commitHash, f.author AS contributor, (f.insertions + f.deletions) AS lineChanges
+          FROM fileChanges_commits_renamed_cached AS f
+          WHERE (f.filePath = ? OR f.filePath LIKE ?)
+          UNION
+          SELECT f.filePath, f.commitHash, co.name AS contributor, (f.insertions + f.deletions) AS lineChanges
+          FROM fileChanges_commits_renamed_cached AS f
+          INNER JOIN commitTrailers_unioned AS co ON f.commitHash = co.commitHash
+          WHERE (f.filePath = ? OR f.filePath LIKE ?) AND co.trailerType = 'coauthor' AND co.name <> f.author
+        )
+        SELECT contributor, SUM(lineChanges) AS totalContribCount
+        FROM commit_contributors
+        GROUP BY contributor
+        ORDER BY totalContribCount DESC, contributor ASC;
+       `,
         async (statement) => {
           statement.bindVarchar(1, objectPath)
           statement.bindVarchar(2, `${objectPath}/%`)
+          statement.bindVarchar(3, objectPath)
+          statement.bindVarchar(4, `${objectPath}/%`)
           return (await statement.runAndReadAll()).getRowObjects()
         },
         "getContributorDistributionForPath(tree)"
       )
     } else {
       res = await this.query(
-        `SELECT author, SUM(insertions + deletions) AS contribSum
-         FROM fileChanges_commits_renamed_cached
-         GROUP BY author
-         ORDER BY contribSum DESC, author ASC;`
+        `WITH commit_contributors AS (
+          SELECT f.filePath, f.commitHash, f.author AS contributor, (f.insertions + f.deletions) AS lineChanges
+          FROM fileChanges_commits_renamed_cached AS f
+          UNION
+          SELECT f.filePath, f.commitHash, co.name AS contributor, (f.insertions + f.deletions) AS lineChanges
+          FROM fileChanges_commits_renamed_cached AS f
+          INNER JOIN commitTrailers_unioned AS co ON f.commitHash = co.commitHash
+          WHERE co.trailerType = 'coauthor' AND co.name <> f.author
+        )
+        SELECT contributor, SUM(lineChanges) AS totalContribCount
+        FROM commit_contributors
+        GROUP BY contributor
+        ORDER BY totalContribCount DESC, contributor ASC;
+       `
       )
     }
 
     return res.map((row) => {
-      return { contributor: row["author"] as string, contribs: Number(row["contribSum"]) }
+      return { contributor: row["contributor"] as string, contribs: Number(row["totalContribCount"]) }
     })
   }
 

--- a/src/analyzer/DB.server.ts
+++ b/src/analyzer/DB.server.ts
@@ -500,8 +500,18 @@ export default class DB {
   }
 
   public async getContributorCountPerFile(): Promise<Record<string, number>> {
-    const res = await this.query(`SELECT filePath, count(DISTINCT author) AS contributorCount
-      FROM fileChanges_commits_renamed_cached
+    const res = await this.query(/*sql*/ `
+      WITH file_people AS (
+        SELECT f.filePath, f.author AS person_name, f.authorEmail AS person_email
+        FROM filechanges_commits_renamed_cached AS f
+        UNION
+        SELECT f.filePath, co.name AS person_name, co.email AS person_email
+        FROM filechanges_commits_renamed_cached AS f
+        INNER JOIN commitTrailers_unioned AS co ON f.commitHash = co.commitHash
+        WHERE co.trailerType = 'coauthor'
+      )
+      SELECT filePath, COUNT(DISTINCT person_name) AS contributorCount
+      FROM file_people
       GROUP BY filePath;
     `)
 
@@ -533,20 +543,40 @@ export default class DB {
 
   public async getUniqueContributorsForPath(objectPath: string): Promise<string[]> {
     //Respects aliases for contributors through commits_unioned view
-    const res = await this.query(`SELECT DISTINCT author
-      FROM fileChanges_commits_renamed_cached
-      WHERE filePath GLOB '${objectPath}*'
+    const res = await this.query(/*sql*/ `
+      WITH file_contributors AS (
+        SELECT f.filePath, f.author AS contributor
+        FROM filechanges_commits_renamed_cached AS f
+        WHERE f.filePath GLOB '${objectPath}*'
+        UNION
+        SELECT f.filePath, ca.name AS contributor
+        FROM filechanges_commits_renamed_cached AS f
+        JOIN commitTrailers_unioned AS ca ON f.commitHash = ca.commitHash
+        WHERE ca.trailerType = 'coauthor' AND f.filePath GLOB '${objectPath}*'
+      )
+      SELECT DISTINCT contributor
+      FROM file_contributors;
     `)
-    return res.map((row) => row["author"] as string)
+    return res.map((row) => row["contributor"] as string)
   }
 
   public async getContributorContributionsForPath(): Promise<
     Record<string, { contributor: string; contribcount: number }[]>
   > {
-    const res = await this.query(`SELECT filePath, author, SUM(insertions + deletions) AS totalContribCount
-    FROM fileChanges_commits_renamed_cached
-    GROUP BY filePath, author
-  `)
+    const res = await this.query(/*sql*/ `
+      WITH commit_contributors AS (
+        SELECT f.filePath, f.commitHash, f.author AS contributor, (f.insertions + f.deletions) AS lineChanges
+        FROM fileChanges_commits_renamed_cached AS f
+        UNION
+        SELECT f.filePath, f.commitHash, co.name AS contributor, (f.insertions + f.deletions) AS lineChanges
+        FROM fileChanges_commits_renamed_cached AS f
+        INNER JOIN commitTrailers_unioned AS co ON f.commitHash = co.commitHash
+        WHERE co.trailerType = 'coauthor' AND co.name <> f.author
+      )
+      SELECT filePath, contributor, SUM(lineChanges) AS totalContribCount
+      FROM commit_contributors
+      GROUP BY filePath, contributor;
+    `)
 
     const result: Record<string, { contributor: string; contribcount: number }[]> = {}
     res.forEach((row) => {
@@ -555,7 +585,7 @@ export default class DB {
         result[filePath] = []
       }
       result[filePath].push({
-        contributor: row["author"] as string,
+        contributor: row["contributor"] as string,
         contribcount: Number(row["totalContribCount"])
       })
     })

--- a/src/analyzer/DB.server.ts
+++ b/src/analyzer/DB.server.ts
@@ -609,30 +609,53 @@ export default class DB {
         INNER JOIN commitTrailers_unioned AS co ON f.commitHash = co.commitHash
         WHERE co.trailerType = 'coauthor' AND (co.name <> f.author)
       ),
-      ranked_contributors AS (
-        SELECT
-          filePath,
-          contributor,
-          SUM(lineChanges) AS totalContribCount,
-          ROW_NUMBER() OVER (
-            PARTITION BY filePath
-            ORDER BY SUM(lineChanges) DESC, contributor ASC
-          ) AS rank
+      contributor_totals AS (
+        SELECT filePath, contributor, SUM(lineChanges) AS totalContribCount
         FROM commit_contributors
         GROUP BY filePath, contributor
+      ),
+      max_per_file AS (
+        SELECT filePath, MAX(totalContribCount) AS maxContribCount
+        FROM contributor_totals
+        GROUP BY filePath
+      ),
+      top_ties AS (
+        SELECT ct.filePath, COUNT(*) AS topCount
+        FROM contributor_totals ct
+        INNER JOIN max_per_file mpf
+          ON ct.filePath = mpf.filePath
+          AND ct.totalContribCount = mpf.maxContribCount
+        GROUP BY ct.filePath
+      ),
+      ranked_contributors AS (
+        SELECT
+          ct.filePath,
+          ct.contributor,
+          ct.totalContribCount,
+          tt.topCount,
+          ROW_NUMBER() OVER (
+            PARTITION BY ct.filePath
+            ORDER BY ct.totalContribCount DESC, ct.contributor ASC
+          ) AS rank
+        FROM contributor_totals ct
+        INNER JOIN top_ties tt ON ct.filePath = tt.filePath
       )
-      SELECT filePath, contributor, totalContribCount
+      SELECT filePath, contributor, totalContribCount, topCount
       FROM ranked_contributors
       WHERE rank = 1;
     `)
 
-    const result: Record<string, { contributor: string; contribcount: number }> = {}
+    const result: Record<string, { contributor: string; contribcount: number; hasTie: boolean }> = {}
     res.forEach((row) => {
       const contributor = row["contributor"]
       if (typeof contributor !== "string") {
         throw new Error("Error when getting top contributor per file: Contributor is not a string")
       }
-      result[row["filePath"] as string] = { contributor: contributor, contribcount: Number(row["totalContribCount"]) }
+      result[row["filePath"] as string] = {
+        contributor: contributor,
+        contribcount: Number(row["totalContribCount"]),
+        hasTie: Number(row["topCount"]) > 1
+      }
     })
 
     return result

--- a/src/analyzer/DB.server.ts
+++ b/src/analyzer/DB.server.ts
@@ -229,6 +229,11 @@ export default class DB {
       SELECT f.commitHash, f.insertions, f.deletions, f.filePath, author, c.authorEmail, c.committerTime, c.authorTime FROM
       fileChanges f JOIN commits_unioned c on f.commitHash = c.hash;
 
+      CREATE OR REPLACE VIEW commitTrailers_unioned AS
+      SELECT co.commitHash, CASE WHEN u.displayName IS NOT NULL THEN u.displayName ELSE co.name END AS name, co.email, co.trailerType FROM
+      commitTrailers AS co LEFT JOIN (SELECT displayName, email, name FROM contributorGroups) AS u
+      ON (co.name = u.name AND co.email = u.email);
+
       CREATE OR REPLACE VIEW fileChanges_commits_renamed AS
       SELECT f.commitHash, f.insertions, f.deletions, f.author, f.authorEmail, f.committerTime, f.authorTime,
           CASE

--- a/src/analyzer/ServerInstance.server.ts
+++ b/src/analyzer/ServerInstance.server.ts
@@ -1,4 +1,5 @@
 import DB from "~/analyzer/DB.server.ts"
+import { getCoAuthors } from "~/analyzer/coauthors.server.ts"
 import { GitCaller } from "~/analyzer/git-caller.server.ts"
 import type {
   GitBlobObject,
@@ -184,6 +185,7 @@ export default class ServerInstance {
       const hash = groups.hash
       const contributionsString = groups.contributions
       const modesString = groups.modes
+      const coauthors = getCoAuthors(groups.trailers)
       const fileChanges: FileChange[] = []
 
       if (modesString) {
@@ -227,7 +229,7 @@ export default class ServerInstance {
         committerTime,
         authorTime,
         hash,
-        coauthors: [],
+        coauthors: coauthors,
         fileChanges
       })
     }
@@ -286,7 +288,8 @@ export default class ServerInstance {
         hash,
         fileChanges,
         message,
-        body
+        body,
+        coauthors: getCoAuthors(body)
       })
     }
     return commits

--- a/src/analyzer/ServerInstance.server.ts
+++ b/src/analyzer/ServerInstance.server.ts
@@ -229,7 +229,7 @@ export default class ServerInstance {
         committerTime,
         authorTime,
         hash,
-        coauthors: coauthors,
+        coauthors,
         fileChanges
       })
     }
@@ -267,6 +267,7 @@ export default class ServerInstance {
       const authorTime = Number(groups.dateAuthor)
       const hash = groups.hash
       const contributionsString = groups.contributions
+      const coauthors = getCoAuthors(body)
       const fileChanges: FileChange[] = []
 
       if (contributionsString) {
@@ -289,7 +290,7 @@ export default class ServerInstance {
         fileChanges,
         message,
         body,
-        coauthors: getCoAuthors(body)
+        coauthors
       })
     }
     return commits

--- a/src/analyzer/coauthors.server.test.ts
+++ b/src/analyzer/coauthors.server.test.ts
@@ -10,7 +10,7 @@ describe("getCoAuthors", () => {
   })
 
   it("should return a single co-author", () => {
-    const description = "This is a commit message.\n\nCo-authored-by: John Doe <john.doe@example.com>"
+    const description = "This is a commit message.\n\nCo-Authored-By: John Doe <john.doe@example.com>"
     const result: Person[] = getCoAuthors(description)
     expect(result).toEqual([{ name: "John Doe", email: "john.doe@example.com" }])
   })
@@ -70,6 +70,13 @@ describe("getCoAuthors", () => {
     const actual = getCoAuthors(sampleDescription)
     expect(actual).toStrictEqual(expected)
   })
+
+  it("should parse co-authors case-insensitively", () => {
+    const description = "Feature work\n\nco-authored-by: Jane Doe <jane@example.com>"
+    const result: Person[] = getCoAuthors(description)
+    expect(result).toEqual([{ name: "Jane Doe", email: "jane@example.com" }])
+  })
+
   it("should ignore invalid co-author entries", () => {
     const description = `This is a commit message.
 

--- a/src/analyzer/coauthors.server.ts
+++ b/src/analyzer/coauthors.server.ts
@@ -1,7 +1,7 @@
 import type { Person } from "~/shared/model"
 
 export function getCoAuthors(description: string) {
-  const coauthorRegex = /Co-authored-by: (?<name>.*) <(?<email>.*)>/gm
+  const coauthorRegex = /Co-authored-by: (?<name>.*) <(?<email>.*)>/gim
   const coauthormatches = description.matchAll(coauthorRegex)
   let value = coauthormatches.next().value
   const coauthors: Person[] = []

--- a/src/analyzer/git-caller.server.ts
+++ b/src/analyzer/git-caller.server.ts
@@ -330,7 +330,7 @@ export class GitCaller {
       "--summary",
       "--numstat",
       // "--cc", // include file changes for merge commits
-      '--format="<|%aN|><|%aE|><|%ct %at|><|%H|>"'
+      '--format="<|%aN|><|%aE|><|%ct %at|><|%(trailers)|><|%H|>"'
     ]
 
     const result = (await runProcess(this.repositoryPath, "git", args, instance, index)) as string

--- a/src/components/inspection/CommitHistory.tsx
+++ b/src/components/inspection/CommitHistory.tsx
@@ -95,17 +95,27 @@ function CommitListEntry(props: { value: FullCommitDTO; authorColor: string }) {
       <div className="w-min-content flex items-start">
         <div className="flex-end flex flex-row-reverse">
           {props.value.coauthors.length > 0
-            ? props.value.coauthors
-                .slice(0, 3)
-                .map((coauthor) => (
+            ? props.value.coauthors.slice(0, 3).map((coauthor) => {
+                const coauthorColor = contributorColors.get(coauthor.name) ?? "grey"
+                return (
                   <LegendDot
-                    key={props.value.hash + coauthor.email}
-                    dotColor={contributorColors.get(coauthor.name) ?? "grey"}
+                    key={props.value.hash + coauthor.email + coauthorColor}
+                    dotColor={coauthorColor}
                     className="z-0 -ml-2.5"
                   />
-                ))
+                )
+              })
             : null}
-          <LegendDot dotColor={contributorColors.get(props.value.author.name) ?? "grey"} className="z-0" />
+          {(() => {
+            const authorColor = contributorColors.get(props.value.author.name) ?? "grey"
+            return (
+              <LegendDot
+                key={props.value.hash + props.value.author.email + authorColor}
+                dotColor={authorColor}
+                className="z-0"
+              />
+            )
+          })()}
         </div>
       </div>
       <Popover

--- a/src/components/inspection/CommitHistory.tsx
+++ b/src/components/inspection/CommitHistory.tsx
@@ -61,6 +61,11 @@ function InfoEntry(props: { keyString: string; value: string }) {
   )
 }
 
+function formatCoauthors(coauthors: FullCommitDTO["coauthors"]) {
+  if (coauthors.length < 1) return "<none>"
+  return coauthors.map((coauthor) => `${coauthor.name} <${coauthor.email}>`).join(", ")
+}
+
 function FileChangesEntry(props: { fileChanges: FileChange[] }) {
   return (
     <div className="overflow-auto">
@@ -105,8 +110,7 @@ function CommitListEntry(props: { value: FullCommitDTO; authorColor: string }) {
       >
         <div className="grid max-w-lg grid-cols-[auto_1fr] gap-x-3 gap-y-1">
           <InfoEntry keyString="Hash" value={props.value.hash} />
-          <InfoEntry keyString="Author Name" value={props.value.author.name} />
-          <InfoEntry keyString="Author Email" value={props.value.author.email ?? "<unknown>"} />
+          <InfoEntry keyString="Author" value={`${props.value.author.name} <${props.value.author.email}>`} />
           {props.value.committerTime === props.value.authorTime ? (
             <InfoEntry
               keyString="Date"
@@ -131,6 +135,7 @@ function CommitListEntry(props: { value: FullCommitDTO; authorColor: string }) {
             </>
           )}
           <InfoEntry keyString="Message" value={props.value.message} />
+          <InfoEntry keyString="Co-authors" value={formatCoauthors(props.value.coauthors)} />
           <div className="flex grow overflow-hidden text-sm font-semibold text-ellipsis whitespace-pre">Body</div>
           <div className="max-h-64 overflow-auto">
             <p className="text-sm break-all text-ellipsis">

--- a/src/components/inspection/CommitHistory.tsx
+++ b/src/components/inspection/CommitHistory.tsx
@@ -37,7 +37,7 @@ function CommitDistFragment(props: CommitDistFragProps) {
       >
         <CommitHistoryLabel htmlFor={commitDistExpandId} />
       </div>
-      <div className="grid grid-cols-[1fr_auto] items-center justify-center">
+      <div className="grid grid-cols-[max-content_auto] items-center justify-start gap-x-1 gap-y-0.5">
         {props.items.map((value) => (
           <CommitListEntry
             key={value.hash + "--itemContentAccordion"}
@@ -89,19 +89,32 @@ function FileChangesEntry(props: { fileChanges: FileChange[] }) {
 }
 
 function CommitListEntry(props: { value: FullCommitDTO; authorColor: string }) {
+  const [, contributorColors] = useMetrics()
   return (
-    <div
-      title={`By: ${props.value.author.name}`}
-      className="flex min-w-0 items-center gap-1 overflow-hidden text-ellipsis"
-    >
-      <LegendDot dotColor={props.authorColor} contributorColorToChange={props.value.author.name} />
+    <>
+      <div className="w-min-content flex items-start">
+        <div className="flex-end flex flex-row-reverse">
+          {props.value.coauthors.length > 0
+            ? props.value.coauthors
+                .slice(0, 3)
+                .map((coauthor) => (
+                  <LegendDot
+                    key={props.value.hash + coauthor.email}
+                    dotColor={contributorColors.get(coauthor.name) ?? "grey"}
+                    className="z-0 -ml-2.5"
+                  />
+                ))
+            : null}
+          <LegendDot dotColor={contributorColors.get(props.value.author.name) ?? "grey"} className="z-0" />
+        </div>
+      </div>
       <Popover
         triggerClassName="min-w-0 truncate"
         positions={["right", "bottom", "top", "left"]}
         popoverTitle="Commit Details"
         trigger={({ onClick }) => (
           <button
-            className="w-full min-w-0 cursor-pointer truncate text-sm font-bold opacity-80 hover:opacity-70"
+            className="w-full min-w-0 cursor-pointer truncate text-start text-sm font-bold opacity-80 hover:opacity-70"
             onClick={onClick}
           >
             {props.value.message}
@@ -156,7 +169,7 @@ function CommitListEntry(props: { value: FullCommitDTO; authorColor: string }) {
         </div>
         <FileChangesEntry fileChanges={props.value.fileChanges} />
       </Popover>
-    </div>
+    </>
   )
 }
 

--- a/src/components/inspection/CommitsInspection.tsx
+++ b/src/components/inspection/CommitsInspection.tsx
@@ -1,5 +1,5 @@
 import { useQueryState } from "nuqs"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { useFetcher, href, Await } from "react-router"
 import { useData } from "~/contexts/DataContext"
 import type { loader } from "~/routes/view.api.commits"
@@ -13,11 +13,11 @@ export function CommitsInspection() {
   const [path] = useQueryState("path")
   const { databaseInfo } = useData()
   const [commitShowCount, setCommitShowCount] = useState(COMMIT_STEP)
-  const previousData = useRef<ReturnType<typeof useFetcher<typeof loader>>["data"]>(undefined)
+  const [previousData, setPreviousData] = useState<ReturnType<typeof useFetcher<typeof loader>>["data"]>(undefined)
 
   useEffect(() => {
     if (fetcher.data) {
-      previousData.current = fetcher.data
+      setPreviousData(fetcher.data)
     }
   }, [fetcher.data])
 
@@ -43,7 +43,7 @@ export function CommitsInspection() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [commitShowCount, loadCommits])
 
-  const data = fetcher.data ?? previousData.current
+  const data = fetcher.data ?? previousData
 
   if (!data) {
     return (

--- a/src/components/inspection/ContributorsInspection.tsx
+++ b/src/components/inspection/ContributorsInspection.tsx
@@ -53,6 +53,7 @@ export function ContributorsInspection() {
     <ContributorDistribution
       className={fetcher.state !== "idle" ? "opacity-60" : ""}
       contributorDistribution={fetcher.data.contributorDistribution}
+      lineChangesSum={fetcher.data.lineChangesSum}
     />
   )
 }
@@ -61,18 +62,19 @@ const contributorCutoff = 2
 
 function ContributorDistribution({
   className = "",
-  contributorDistribution
+  contributorDistribution,
+  lineChangesSum
 }: {
   className?: string
   contributorDistribution: { contributor: string; contribs: number }[]
+  lineChangesSum: number
 }) {
   const contributorDistributionExpandId = useId()
   const [collapsed, setCollapsed] = useState<boolean>(true)
 
   const contributorsAreCutoff = contributorDistribution.length > contributorCutoff + 1
-  const contribSum = !contributorDistribution
-    ? 0
-    : contributorDistribution.reduce((acc, curr) => acc + curr.contribs, 0)
+  //ContribSum > sum(Contribs) if there are coauthors
+  const contribSum = lineChangesSum ?? 0
 
   return (
     <div className={cn("flex flex-col gap-2", className)}>

--- a/src/components/inspection/ContributorsInspection.tsx
+++ b/src/components/inspection/ContributorsInspection.tsx
@@ -114,7 +114,7 @@ function ContributorDistribution({
           </>
         ) : (
           <>
-            {contributorDistribution.length > 0 && hasContributions(contributorDistribution) ? (
+            {contributorDistribution.length > 0 ? (
               <ContributorDistFragment show items={contributorDistribution} contribSum={contribSum} />
             ) : (
               <p>No contributors found</p>
@@ -124,14 +124,6 @@ function ContributorDistribution({
       </div>
     </div>
   )
-}
-
-function hasContributions(contributors?: { contributor: string; contribs: number }[] | null) {
-  if (!contributors) return false
-  for (const { contribs } of contributors) {
-    if (contribs > 0) return true
-  }
-  return false
 }
 
 function ContributorDistFragment(props: {
@@ -149,7 +141,7 @@ function ContributorDistFragment(props: {
         const contrib = legendItem.contribs
         const contributor = legendItem.contributor
         const roundedContrib = Math.round((contrib / props.contribSum) * 100)
-        const contribPercentage = roundedContrib === 0 ? "<1" : roundedContrib
+        const contribPercentage = props.contribSum == 0 ? "100" : roundedContrib === 0 ? "<1" : roundedContrib
         return (
           <Fragment key={contributor + contrib}>
             <div className="flex items-center gap-1">

--- a/src/components/inspection/MetricsInspection.tsx
+++ b/src/components/inspection/MetricsInspection.tsx
@@ -147,14 +147,20 @@ export function MetricsInspection() {
           ?.map((c) => c.color) ?? []
     },
     TOP_CONTRIBUTOR: {
-      description: "is the top contributor",
+      description: currentFetcherData?.multiTopContributors ? "are top contributors" : "is top contributor",
       icon: mdiAccountGroup,
-      data: currentFetcherData ? (currentFetcherData.topContributor?.contributor ?? UNKNOWN_CATEGORY) : "loading...",
+      data: currentFetcherData
+        ? currentFetcherData.multiTopContributors
+          ? "Multiple people"
+          : (currentFetcherData.topContributor[0].contributor ?? UNKNOWN_CATEGORY)
+        : "loading...",
       inspectionPanels: TopContributorMetric.inspectionPanels,
       actions: { search: true, clear: true, groupContributors: true, shuffleContributorColors: true },
       colors: [
-        currentFetcherData?.topContributor?.contributor
-          ? ((contributorColors.get(currentFetcherData?.topContributor?.contributor) as HexColor) ?? missingInMapColor)
+        currentFetcherData
+          ? currentFetcherData.multiTopContributors
+            ? missingInMapColor
+            : (contributorColors.get(currentFetcherData.topContributor[0].contributor) as HexColor)
           : (missingInMapColor as HexColor)
       ]
     },

--- a/src/metrics/topContributer.ts
+++ b/src/metrics/topContributer.ts
@@ -84,7 +84,7 @@ function setTopContributorColor(
     } else {
       legend.set(MULTIPLE_CONTRIBUTORS, new PointInfo(noEntryColor, 1))
     }
-    cache.categoriesMap.set(blob.path, [{ category: UNKNOWN_CATEGORY, color: noEntryColor }])
+    cache.categoriesMap.set(blob.path, [{ category: MULTIPLE_CONTRIBUTORS, color: noEntryColor }])
   }
 
   if (!topContributor || topContributor.hasTie) {

--- a/src/metrics/topContributer.ts
+++ b/src/metrics/topContributer.ts
@@ -19,7 +19,10 @@ export const TopContributorMetric: CategoricalMetric = {
     if (!top) {
       return "No activity in selected range"
     }
-    if (!contribSum) {
+    if (top.hasTie) {
+      return MULTIPLE_CONTRIBUTORS
+    }
+    if (contribSum === 0) {
       return top.contributor
     }
     const contributorPercentage = Math.round((top.contribcount / contribSum) * 100)
@@ -34,8 +37,11 @@ export const TopContributorMetric: CategoricalMetric = {
     if (!top) {
       return ["No contributors"]
     }
+    if (top.hasTie) {
+      return [MULTIPLE_CONTRIBUTORS]
+    }
     const contribSum = dbi.contribSumPerFile[obj.path]
-    if (!contribSum) {
+    if (contribSum === 0) {
       return [top.contributor]
     }
     const contributorPercentage = Math.round((top.contribcount / contribSum) * 100)
@@ -63,7 +69,7 @@ function setTopContributorColor(
   contributorColors: Record<string, `#${string}`>,
   blob: GitBlobObject,
   cache: MetricCache,
-  topContributorPerFile: Record<string, { contributor: string; contribcount: number }>,
+  topContributorPerFile: Record<string, { contributor: string; contribcount: number; hasTie: boolean }>,
   topContributorCutoff: number,
   contribSumPerFile: Record<string, number>
 ) {
@@ -81,7 +87,24 @@ function setTopContributorColor(
     cache.categoriesMap.set(blob.path, [{ category: UNKNOWN_CATEGORY, color: noEntryColor }])
   }
 
-  if (!topContributor || !contribSum) {
+  if (!topContributor || topContributor.hasTie) {
+    bumpMultiple()
+    return
+  }
+
+  if (contribSum === 0) {
+    const color = contributorColors[topContributor.contributor] ?? noEntryColor
+    cache.categoriesMap.set(blob.path, [{ category: topContributor.contributor, color }])
+
+    if (legend.has(topContributor.contributor)) {
+      legend.get(topContributor.contributor)?.add(1)
+      return
+    }
+    legend.set(topContributor.contributor, new PointInfo(color, 1))
+    return
+  }
+
+  if (contribSum === undefined) {
     bumpMultiple()
     return
   }

--- a/src/metrics/topContributer.ts
+++ b/src/metrics/topContributer.ts
@@ -2,7 +2,7 @@ import type { GitBlobObject } from "~/shared/model"
 import type { PointLegendData } from "~/components/legend/PointLegend"
 import { PointInfo, PointLegend } from "~/components/legend/PointLegend"
 import type { CategoricalMetric, MetricCache } from "~/metrics/metrics"
-import { MULTIPLE_CONTRIBUTORS, noEntryColor, UNKNOWN_CATEGORY } from "~/const"
+import { MULTIPLE_CONTRIBUTORS, noEntryColor } from "~/const"
 import { mdiPodiumGold } from "@mdi/js"
 import { ContributorsInspection } from "~/components/inspection/ContributorsInspection"
 import { PercentageSlider } from "~/components/PercentageSlider"
@@ -86,12 +86,18 @@ function setTopContributorColor(
     }
     cache.categoriesMap.set(blob.path, [{ category: MULTIPLE_CONTRIBUTORS, color: noEntryColor }])
   }
+  //No activity in selected range == no top contributor
+  if (!topContributor) {
+    return
+  }
 
-  if (!topContributor || topContributor.hasTie) {
+  //There is a tie between top contributors, so we can't determine a single top contributor
+  if (topContributor.hasTie) {
     bumpMultiple()
     return
   }
 
+  //There is an empty file
   if (contribSum === 0) {
     const color = contributorColors[topContributor.contributor] ?? noEntryColor
     cache.categoriesMap.set(blob.path, [{ category: topContributor.contributor, color }])
@@ -104,11 +110,7 @@ function setTopContributorColor(
     return
   }
 
-  if (contribSum === undefined) {
-    bumpMultiple()
-    return
-  }
-
+  //The top contributor does not meet the cutoff
   const contributorPercentage = (topContributor.contribcount / contribSum) * 100
   if (contributorPercentage < topContributorCutoff) {
     bumpMultiple()

--- a/src/routes/view.api.commits.tsx
+++ b/src/routes/view.api.commits.tsx
@@ -32,8 +32,6 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
       }
 
       return fullCommits.map((commit) => {
-        const alias = unions.find(({ name, email }) => name === commit.author.name && email === commit.author.email)
-        if (!alias) return commit
         return {
           ...commit,
           author: applyUnionAlias(commit.author),

--- a/src/routes/view.api.commits.tsx
+++ b/src/routes/view.api.commits.tsx
@@ -21,15 +21,23 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
       const gitLogResult = await instance.gitCaller.gitLogSpecificCommits(commitHashes)
       const fullCommits = await instance.getFullCommits(gitLogResult)
       const unions = await instance.db.getRawUnions()
+
+      const applyUnionAlias = (person: { name: string; email: string }) => {
+        const alias = unions.find(({ name, email }) => name === person.name && email === person.email)
+        if (!alias) return person
+        return {
+          name: alias.displayName,
+          email: alias.email
+        }
+      }
+
       return fullCommits.map((commit) => {
         const alias = unions.find(({ name, email }) => name === commit.author.name && email === commit.author.email)
         if (!alias) return commit
         return {
           ...commit,
-          author: {
-            name: alias.displayName,
-            email: commit.author.email
-          }
+          author: applyUnionAlias(commit.author),
+          coauthors: commit.coauthors.map((coauthor) => applyUnionAlias(coauthor))
         }
       })
     })(),

--- a/src/routes/view.api.commits.tsx
+++ b/src/routes/view.api.commits.tsx
@@ -22,8 +22,16 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
       const fullCommits = await instance.getFullCommits(gitLogResult)
       const unions = await instance.db.getRawUnions()
 
+      const aliasByIdentity = new Map<string, { displayName: string; email: string }>()
+      unions.forEach((union) => {
+        aliasByIdentity.set(`${union.name}\u0000${union.email}`, {
+          displayName: union.displayName,
+          email: union.email
+        })
+      })
+
       const applyUnionAlias = (person: { name: string; email: string }) => {
-        const alias = unions.find(({ name, email }) => name === person.name && email === person.email)
+        const alias = aliasByIdentity.get(`${person.name}\u0000${person.email}`)
         if (!alias) return person
         return {
           name: alias.displayName,

--- a/src/routes/view.api.contributor-distribution.tsx
+++ b/src/routes/view.api.contributor-distribution.tsx
@@ -13,6 +13,7 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
   return {
     path: objectPath,
     existsInRange: await instance.db.pathExistsInSelectedRange(objectPath, isBlob),
-    contributorDistribution: await instance.db.getContributorDistributionForPath(objectPath)
+    contributorDistribution: await instance.db.getContributorDistributionForPath(objectPath),
+    lineChangesSum: await instance.db.getLineChangesSumForPath(objectPath)
   }
 }

--- a/src/routes/view.api.inspect.metrics.tsx
+++ b/src/routes/view.api.inspect.metrics.tsx
@@ -15,7 +15,9 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
   return {
     path: objectPath,
     existsInRange: await instance.db.pathExistsInSelectedRange(objectPath, isBlob),
-    topContributor: topContributorData.length > 0 ? topContributorData[0] : null,
+    topContributor: topContributorData,
+    multiTopContributors:
+      topContributorData.length > 1 && topContributorData[0].contribs === topContributorData[1].contribs,
     amountOfCommits: await instance.db.getCommitCountForPath(objectPath),
     contributors: await instance.db.getUniqueContributorsForPath(objectPath)
   }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,7 +1,7 @@
 export const gitLogRegex =
   /"author\s+<\|(?<author>.*?)\|>\s+email\s+<\|(?<authorEmail>.*?)\|>\s+date\s+<\|(?<dateCommitter>\d+)\s(?<dateAuthor>\d+)\|>\s+message\s+<\|(?<message>[\s\S]*?)\|>\s+body\s+<\|(?<body>[\s\S]*?)\|>\s+hash\s+<\|(?<hash>.+?)\|>"\s*(?<contributions>(?:(?:\d+|-)\s+(?:\d+|-)\s+.+\s?)*)(?<modes>(?:\s.+\s*)*)/gmu
 export const gitLogRegexSimple =
-  /"<\|(?<author>.*?)\|><\|(?<authorEmail>.*?)\|><\|(?<dateCommitter>\d+)\s(?<dateAuthor>\d+)\|><\|(?<hash>.+?)\|>"\s*(?<contributions>(?:(?:\d+|-)\s+(?:\d+|-)\s+.+\s?)*)(?<modes>(?:\s.+\s*)*)/gmu
+  /"<\|(?<author>.*?)\|><\|(?<authorEmail>.*?)\|><\|(?<dateCommitter>\d+)\s(?<dateAuthor>\d+)\|>\s*<\|(?<trailers>[\s\S]*?)\|><\|(?<hash>.+?)\|>"\s*(?<contributions>(?:(?:\d+|-)\s+(?:\d+|-)\s+.+\s?)*)(?<modes>(?:\s.+\s*)*)/gmu
 export const contribRegex = /(?<insertions>\d+|-)\s+(?<deletions>\d+|-)\s+(?<file>.+)/gm
 export const treeRegex = /^\S+? (?<type>\S+) (?<hash>\S+)\s+(?<size>\S+)\s+(?<path>.+)/gm
 export const modeRegex = /\s(?<mode>\w+)\s\w+\s\d+\s(?<file>.+)/gmu

--- a/src/shared/model.ts
+++ b/src/shared/model.ts
@@ -202,7 +202,7 @@ export interface RepoData {
 }
 
 export interface DatabaseInfo {
-  topContributors: Record<string, { contributor: string; contribcount: number }>
+  topContributors: Record<string, { contributor: string; contribcount: number; hasTie: boolean }>
   commitCounts: Record<string, number>
   fileSizes: Record<string, number>
   lastChanged: Record<string, number>

--- a/src/shared/model.ts
+++ b/src/shared/model.ts
@@ -165,6 +165,7 @@ export interface CompletedResult {
 export interface FullCommitDTO extends CommitDTO {
   body: string
   message: string
+  coauthors: Person[]
   fileChanges: FileChange[]
 }
 


### PR DESCRIPTION
Resolves #746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Co-authors are now captured, stored, and shown alongside authors; contributor counts, rankings, and distributions include co-authors. Line-change totals per path are exposed for percentage calculations. Top-contributor results now indicate ties and support a “multiple contributors” mode.
  * Author/co-author identities are unified with display-name aliasing.

* **Bug Fixes**
  * Co-author headers parsed case-insensitively for more reliable detection.

* **Style**
  * Commit history and metrics visuals updated with co-author dots, combined author popovers, and adjusted layout.

* **Chores**
  * Color-seed persistence and retrieval behavior improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->